### PR TITLE
fix: get the closest rh portal parent for dom ops instead of getting anywhere from body

### DIFF
--- a/dist/react-big-calendar.esm.js
+++ b/dist/react-big-calendar.esm.js
@@ -991,7 +991,10 @@ var Selection = /*#__PURE__*/ (function () {
         _ref3$longPressThresh === void 0 ? 250 : _ref3$longPressThresh,
       _ref3$validContainers = _ref3.validContainers,
       validContainers =
-        _ref3$validContainers === void 0 ? [] : _ref3$validContainers
+        _ref3$validContainers === void 0 ? [] : _ref3$validContainers,
+      _ref3$targetHostMarke = _ref3.targetHostMarker,
+      targetHostMarker =
+        _ref3$targetHostMarke === void 0 ? null : _ref3$targetHostMarke
     _classCallCheck(this, Selection)
     this.isDetached = false
     this.container = node
@@ -1005,7 +1008,7 @@ var Selection = /*#__PURE__*/ (function () {
      * event listener target for container
      * we need this to make the calendar work inside shadow roots
      */
-    this._targetHost = getTargetHost(this.container)
+    this._targetHost = getTargetHost(targetHostMarker || this.container())
     this._handleInitialEvent = this._handleInitialEvent.bind(this)
     this._handleMoveEvent = this._handleMoveEvent.bind(this)
     this._handleTerminatingEvent = this._handleTerminatingEvent.bind(this)
@@ -1641,6 +1644,7 @@ var BackgroundCells = /*#__PURE__*/ (function (_React$Component) {
         var node = this.containerRef.current
         var selector = (this._selector = new Selection(this.props.container, {
           longPressThreshold: this.props.longPressThreshold,
+          targetHostMarker: this.containerRef.current,
         }))
         var selectorClicksHandler = function selectorClicksHandler(
           point,
@@ -2459,12 +2463,6 @@ var Header = function Header(_ref) {
     label
   )
 }
-Header.propTypes =
-  process.env.NODE_ENV !== 'production'
-    ? {
-        label: PropTypes.node,
-      }
-    : {}
 
 var DateHeader = function DateHeader(_ref) {
   var label = _ref.label,
@@ -3749,6 +3747,7 @@ var DayColumn = /*#__PURE__*/ (function (_React$Component) {
         },
         {
           longPressThreshold: longPressThreshold,
+          targetHostMarker: _this.containerRef.current,
         }
       ))
       var maybeSelect = function maybeSelect(box) {

--- a/dist/react-big-calendar.js
+++ b/dist/react-big-calendar.js
@@ -45400,7 +45400,10 @@
           _ref3$longPressThresh === void 0 ? 250 : _ref3$longPressThresh,
         _ref3$validContainers = _ref3.validContainers,
         validContainers =
-          _ref3$validContainers === void 0 ? [] : _ref3$validContainers
+          _ref3$validContainers === void 0 ? [] : _ref3$validContainers,
+        _ref3$targetHostMarke = _ref3.targetHostMarker,
+        targetHostMarker =
+          _ref3$targetHostMarke === void 0 ? null : _ref3$targetHostMarke
       _classCallCheck(this, Selection)
       this.isDetached = false
       this.container = node
@@ -45414,7 +45417,7 @@
        * event listener target for container
        * we need this to make the calendar work inside shadow roots
        */
-      this._targetHost = getTargetHost(this.container)
+      this._targetHost = getTargetHost(targetHostMarker || this.container())
       this._handleInitialEvent = this._handleInitialEvent.bind(this)
       this._handleMoveEvent = this._handleMoveEvent.bind(this)
       this._handleTerminatingEvent = this._handleTerminatingEvent.bind(this)
@@ -46051,6 +46054,7 @@
           var node = this.containerRef.current
           var selector = (this._selector = new Selection(this.props.container, {
             longPressThreshold: this.props.longPressThreshold,
+            targetHostMarker: this.containerRef.current,
           }))
           var selectorClicksHandler = function selectorClicksHandler(
             point,
@@ -49823,6 +49827,7 @@
           },
           {
             longPressThreshold: longPressThreshold,
+            targetHostMarker: _this.containerRef.current,
           }
         ))
         var maybeSelect = function maybeSelect(box) {
@@ -50372,6 +50377,14 @@
     var label = _ref.label
     return /*#__PURE__*/ React.createElement(React.Fragment, null, label)
   }
+  ResourceHeader.propTypes =
+    'development' !== 'production'
+      ? {
+          label: propTypesExports.node,
+          index: propTypesExports.number,
+          resource: propTypesExports.object,
+        }
+      : {}
 
   var TimeGridHeader = /*#__PURE__*/ (function (_React$Component) {
     _inherits(TimeGridHeader, _React$Component)

--- a/dist/react-big-calendar.min.js
+++ b/dist/react-big-calendar.min.js
@@ -362,20 +362,20 @@
   var I = 60115,
     U = 60116
   if ('function' == typeof Symbol && Symbol.for) {
-    var W = Symbol.for
-    ;(z = W('react.element')),
-      (L = W('react.portal')),
-      (O.Fragment = W('react.fragment')),
-      (O.StrictMode = W('react.strict_mode')),
-      (O.Profiler = W('react.profiler')),
-      (j = W('react.provider')),
-      (A = W('react.context')),
-      (F = W('react.forward_ref')),
-      (O.Suspense = W('react.suspense')),
-      (I = W('react.memo')),
-      (U = W('react.lazy'))
+    var H = Symbol.for
+    ;(z = H('react.element')),
+      (L = H('react.portal')),
+      (O.Fragment = H('react.fragment')),
+      (O.StrictMode = H('react.strict_mode')),
+      (O.Profiler = H('react.profiler')),
+      (j = H('react.provider')),
+      (A = H('react.context')),
+      (F = H('react.forward_ref')),
+      (O.Suspense = H('react.suspense')),
+      (I = H('react.memo')),
+      (U = H('react.lazy'))
   }
-  var H = 'function' == typeof Symbol && Symbol.iterator
+  var W = 'function' == typeof Symbol && Symbol.iterator
   function V(e) {
     for (
       var t = 'https://reactjs.org/docs/error-decoder.html?invariant=' + e,
@@ -525,7 +525,7 @@
       ((u = (function (e) {
         return null === e || 'object' != typeof e
           ? null
-          : 'function' == typeof (e = (H && e[H]) || e['@@iterator'])
+          : 'function' == typeof (e = (W && e[W]) || e['@@iterator'])
           ? e
           : null
       })(e)),
@@ -907,7 +907,7 @@
   function Ue(e) {
     return (e % 4 == 0 && e % 100 != 0) || e % 400 == 0 ? 29 : 28
   }
-  function We(e, t, n) {
+  function He(e, t, n) {
     switch (((e = new Date(e)), n)) {
       case Me:
       case Ce:
@@ -946,8 +946,8 @@
     }
     throw new TypeError('Invalid units: "' + n + '"')
   }
-  function He(e, t, n) {
-    return We(e, -t, n)
+  function We(e, t, n) {
+    return He(e, -t, n)
   }
   function Ve(e, t, n) {
     switch (((e = new Date(e)), t)) {
@@ -968,12 +968,12 @@
         e = et(e, 0)
     }
     return (
-      t === je && (e = He(e, lt(e) % 10, 'year')),
-      t === Ae && (e = He(e, lt(e) % 100, 'year')),
+      t === je && (e = We(e, lt(e) % 10, 'year')),
+      t === Ae && (e = We(e, lt(e) % 100, 'year')),
       t === Ne &&
         (e = (function (e, t, n) {
           var r = (ot(e) + 7 - (n || 0)) % 7
-          return void 0 === t ? r : We(e, t - r, Re)
+          return void 0 === t ? r : He(e, t - r, Re)
         })(e, 0, n)),
       e
     )
@@ -985,7 +985,7 @@
       case Le:
       case ze:
       case Ne:
-        ;(e = He((e = We(e, 1, t)), 1, Re)).setHours(23, 59, 59, 999)
+        ;(e = We((e = He(e, 1, t)), 1, Re)).setHours(23, 59, 59, 999)
         break
       case Re:
         e.setHours(23, 59, 59, 999)
@@ -993,7 +993,7 @@
       case Pe:
       case Te:
       case Ce:
-        e = He((e = We(e, 1, t)), 1, Me)
+        e = We((e = He(e, 1, t)), 1, Me)
     }
     return e
   }
@@ -1077,12 +1077,12 @@
   }
   function pt(e, t) {
     for (var n = ft(e, t), r = dt(e, t), o = []; Xe(n, r, 'day'); )
-      o.push(n), (n = We(n, 1, 'day'))
+      o.push(n), (n = He(n, 1, 'day'))
     return o
   }
   function vt(e, t) {
     var n = Ve(e, t)
-    return $e(n, e) ? n : We(n, 1, t)
+    return $e(n, e) ? n : He(n, 1, t)
   }
   function ht(e, t) {
     for (
@@ -1095,7 +1095,7 @@
       Xe(r, t, n);
 
     )
-      o.push(r), (r = We(r, 1, n))
+      o.push(r), (r = He(r, 1, n))
     return o
   }
   function mt(e, t) {
@@ -1210,7 +1210,7 @@
       (this.neq = t.neq || Ye),
       (this.startOf = t.startOf || Ve),
       (this.endOf = t.endOf || Be),
-      (this.add = t.add || We),
+      (this.add = t.add || He),
       (this.range = t.range || ht),
       (this.diff = t.diff || yt),
       (this.ceil = t.ceil || vt),
@@ -1310,9 +1310,9 @@
     Ft = 'object' == typeof S && S && S.Object === Object && S,
     It = Ft,
     Ut = 'object' == typeof self && self && self.Object === Object && self,
-    Wt = It || Ut || Function('return this')(),
-    Ht = Wt.Symbol,
-    Vt = Ht,
+    Ht = It || Ut || Function('return this')(),
+    Wt = Ht.Symbol,
+    Vt = Wt,
     Bt = Object.prototype,
     $t = Bt.hasOwnProperty,
     Yt = Bt.toString,
@@ -1332,7 +1332,7 @@
     Gt = function (e) {
       return Qt.call(e)
     },
-    Jt = Ht ? Ht.toStringTag : void 0
+    Jt = Wt ? Wt.toStringTag : void 0
   var Zt = function (e) {
     return null == e
       ? void 0 === e
@@ -1458,12 +1458,12 @@
       i[a++] = Ln(e, o, (o += t))
     return i
   }
-  function Wn(e) {
+  function Hn(e) {
     return (e && e.ownerDocument) || document
   }
-  function Hn(e, t) {
+  function Wn(e, t) {
     return (function (e) {
-      var t = Wn(e)
+      var t = Hn(e)
       return (t && t.defaultView) || window
     })(e).getComputedStyle(e, t)
   }
@@ -1480,7 +1480,7 @@
     var n = '',
       r = ''
     if ('string' == typeof t)
-      return e.style.getPropertyValue($n(t)) || Hn(e).getPropertyValue($n(t))
+      return e.style.getPropertyValue($n(t)) || Wn(e).getPropertyValue($n(t))
     Object.keys(t).forEach(function (o) {
       var a = t[o]
       a || 0 === a
@@ -1521,7 +1521,7 @@
   var Gn = Xn('pageXOffset'),
     Jn = Xn('pageYOffset')
   function Zn(e) {
-    var t = Wn(e),
+    var t = Hn(e),
       n = { top: 0, left: 0, height: 0, width: 0 },
       r = t && t.documentElement
     return r && Kn(r, e)
@@ -1543,7 +1543,7 @@
         t ||
         (function (e) {
           for (
-            var t, n = Wn(e), r = e && e.offsetParent;
+            var t, n = Hn(e), r = e && e.offsetParent;
             (t = r) &&
             'offsetParent' in t &&
             'HTML' !== r.nodeName &&
@@ -1754,7 +1754,7 @@
   function Ur() {
     return !/^((?!chrome|android).)*safari/i.test(Ir())
   }
-  function Wr(e, t, n) {
+  function Hr(e, t, n) {
     void 0 === t && (t = !1), void 0 === n && (n = !1)
     var r = e.getBoundingClientRect(),
       o = 1,
@@ -1780,8 +1780,8 @@
       y: s,
     }
   }
-  function Hr(e) {
-    var t = Wr(e),
+  function Wr(e) {
+    var t = Hr(e),
       n = e.offsetWidth,
       r = e.offsetHeight
     return (
@@ -1897,7 +1897,7 @@
                 : eo(e, Sr)
             )
           })(o.padding, n),
-          f = Hr(a),
+          f = Wr(a),
           d = 'y' === u ? yr : kr,
           p = 'y' === u ? br : wr,
           v =
@@ -2119,7 +2119,7 @@
     return { scrollLeft: t.pageXOffset, scrollTop: t.pageYOffset }
   }
   function vo(e) {
-    return Wr(qr(e)).left + po(e).scrollLeft
+    return Hr(qr(e)).left + po(e).scrollLeft
   }
   function ho(e) {
     var t = $r(e),
@@ -2175,7 +2175,7 @@
         )
       : Nr(t)
       ? (function (e, t) {
-          var n = Wr(e, !1, 'fixed' === t)
+          var n = Hr(e, !1, 'fixed' === t)
           return (
             (n.top = n.top + e.clientTop),
             (n.left = n.left + e.clientLeft),
@@ -2312,7 +2312,7 @@
       b = e.rects.popper,
       w = e.elements[v ? y : d],
       k = wo(Nr(w) ? w : w.contextElement || qr(e.elements.popper), u, c, i),
-      E = Wr(e.elements.reference),
+      E = Hr(e.elements.reference),
       S = ko({ reference: E, element: b, strategy: 'absolute', placement: o }),
       D = yo(Object.assign({}, b, S)),
       _ = d === Or ? D : E,
@@ -2587,14 +2587,14 @@
             A = y === Dr ? S[R] : D[R],
             F = y === Dr ? -D[R] : -S[R],
             I = t.elements.arrow,
-            U = p && I ? Hr(I) : { width: 0, height: 0 },
-            W = t.modifiersData['arrow#persistent']
+            U = p && I ? Wr(I) : { width: 0, height: 0 },
+            H = t.modifiersData['arrow#persistent']
               ? t.modifiersData['arrow#persistent'].padding
               : { top: 0, right: 0, bottom: 0, left: 0 },
-            H = W[T],
-            V = W[P],
+            W = H[T],
+            V = H[P],
             B = Jr(0, S[R], U[R]),
-            $ = b ? S[R] / 2 - j - B - H - x.mainAxis : A - B - H - x.mainAxis,
+            $ = b ? S[R] / 2 - j - B - W - x.mainAxis : A - B - W - x.mainAxis,
             Y = b ? -S[R] / 2 + j + B + V + x.mainAxis : F + B + V + x.mainAxis,
             q = t.elements.arrow && Xr(t.elements.arrow),
             K = q ? ('y' === w ? q.clientTop || 0 : q.clientLeft || 0) : 0,
@@ -2643,7 +2643,7 @@
           return 1 !== n || 1 !== r
         })(t),
       l = qr(t),
-      u = Wr(e, i, n),
+      u = Hr(e, i, n),
       s = { scrollLeft: 0, scrollTop: 0 },
       c = { x: 0, y: 0 }
     return (
@@ -2654,7 +2654,7 @@
               ? { scrollLeft: (o = r).scrollLeft, scrollTop: o.scrollTop }
               : po(r)),
         zr(t)
-          ? (((c = Wr(t, !0)).x += t.clientLeft), (c.y += t.clientTop))
+          ? (((c = Hr(t, !0)).x += t.clientLeft), (c.y += t.clientTop))
           : l && (c.x = vo(l))),
       {
         x: u.left + s.scrollLeft - c.x,
@@ -2789,7 +2789,7 @@
                 if (Ro(t, n)) {
                   ;(l.rects = {
                     reference: Co(t, Xr(n), 'fixed' === l.options.strategy),
-                    popper: Hr(n),
+                    popper: Wr(n),
                   }),
                     (l.reset = !1),
                     (l.placement = l.options.placement),
@@ -2987,14 +2987,14 @@
         Io = e
       },
     },
-    Wo = {},
     Ho = {},
+    Wo = {},
     Vo = {
       get exports() {
-        return Ho
+        return Wo
       },
       set exports(e) {
-        Ho = e
+        Wo = e
       },
     },
     Bo = {}
@@ -3325,7 +3325,7 @@
    */
   var $o = _,
     Yo = R,
-    qo = Ho
+    qo = Wo
   function Ko(e) {
     for (
       var t = 'https://reactjs.org/docs/error-decoder.html?invariant=' + e,
@@ -3795,7 +3795,7 @@
       return e.body
     }
   }
-  function Wa(e, t) {
+  function Ha(e, t) {
     var n = t.checked
     return Yo({}, t, {
       defaultChecked: void 0,
@@ -3804,7 +3804,7 @@
       checked: null != n ? n : e._wrapperState.initialChecked,
     })
   }
-  function Ha(e, t) {
+  function Wa(e, t) {
     var n = null == t.defaultValue ? '' : t.defaultValue,
       r = null != t.checked ? t.checked : t.defaultChecked
     ;(n = ja(null != t.value ? t.value : n)),
@@ -4232,7 +4232,7 @@
   function Ui(e) {
     if (Fi(e) !== e) throw Error(Ko(188))
   }
-  function Wi(e) {
+  function Hi(e) {
     if (
       ((e = (function (e) {
         var t = e.alternate
@@ -4309,7 +4309,7 @@
     }
     return null
   }
-  function Hi(e, t) {
+  function Wi(e, t) {
     for (var n = e.alternate; null !== t; ) {
       if (t === e || t === n) return !0
       t = t.return
@@ -4398,7 +4398,7 @@
   function il(e) {
     if (null !== e.blockedOn) return !1
     for (var t = e.targetContainers; 0 < t.length; ) {
-      var n = Wl(e.domEventName, e.eventSystemFlags, t[0], e.nativeEvent)
+      var n = Hl(e.domEventName, e.eventSystemFlags, t[0], e.nativeEvent)
       if (null !== n)
         return null !== (t = Bs(n)) && Bi(t), (e.blockedOn = n), !1
       t.shift()
@@ -4416,7 +4416,7 @@
         break
       }
       for (var t = e.targetContainers; 0 < t.length; ) {
-        var n = Wl(e.domEventName, e.eventSystemFlags, t[0], e.nativeEvent)
+        var n = Hl(e.domEventName, e.eventSystemFlags, t[0], e.nativeEvent)
         if (null !== n) {
           e.blockedOn = n
           break
@@ -4700,7 +4700,7 @@
       if ((o = 0 == (4 & t)) && 0 < Ki.length && -1 < tl.indexOf(e))
         (e = nl(null, e, t, n, r)), Ki.push(e)
       else {
-        var a = Wl(e, t, n, r)
+        var a = Hl(e, t, n, r)
         if (null === a) o && rl(e, r)
         else {
           if (o) {
@@ -4735,7 +4735,7 @@
         }
       }
   }
-  function Wl(e, t, n, r) {
+  function Hl(e, t, n, r) {
     var o = vi(r)
     if (null !== (o = Vs(o))) {
       var a = Fi(o)
@@ -4754,7 +4754,7 @@
     }
     return Es(e, t, r, o, n), null
   }
-  var Hl = null,
+  var Wl = null,
     Vl = null,
     Bl = null
   function $l() {
@@ -4763,7 +4763,7 @@
       t,
       n = Vl,
       r = n.length,
-      o = 'value' in Hl ? Hl.value : Hl.textContent,
+      o = 'value' in Wl ? Wl.value : Wl.textContent,
       a = o.length
     for (e = 0; e < r && n[e] === o[e]; e++);
     var i = r - e
@@ -5108,9 +5108,9 @@
   function Uu(e, t) {
     if ('change' === e) return t
   }
-  var Wu = !1
+  var Hu = !1
   if (Zo) {
-    var Hu
+    var Wu
     if (Zo) {
       var Vu = 'oninput' in document
       if (!Vu) {
@@ -5118,9 +5118,9 @@
         Bu.setAttribute('oninput', 'return;'),
           (Vu = 'function' == typeof Bu.oninput)
       }
-      Hu = Vu
-    } else Hu = !1
-    Wu = Hu && (!document.documentMode || 9 < document.documentMode)
+      Wu = Vu
+    } else Wu = !1
+    Hu = Wu && (!document.documentMode || 9 < document.documentMode)
   }
   function $u() {
     ju && (ju.detachEvent('onpropertychange', Yu), (Au = ju = null))
@@ -5574,7 +5574,7 @@
           (!(l = 'mouseover' === e || 'pointerover' === e) ||
             0 != (16 & t) ||
             !(s = n.relatedTarget || n.fromElement) ||
-            (!Vs(s) && !s[Ws])) &&
+            (!Vs(s) && !s[Hs])) &&
             (u || l) &&
             ((l =
               o.window === o
@@ -5636,7 +5636,7 @@
         )
           var m = Uu
         else if (zu(l))
-          if (Wu) m = Xu
+          if (Hu) m = Xu
           else {
             m = Ku
             var g = qu
@@ -5704,7 +5704,7 @@
             'ko' !== n.locale &&
             (Ru || 'onCompositionStart' !== b
               ? 'onCompositionEnd' === b && Ru && (y = $l())
-              : ((Vl = 'value' in (Hl = o) ? Hl.value : Hl.textContent),
+              : ((Vl = 'value' in (Wl = o) ? Wl.value : Wl.textContent),
                 (Ru = !0))),
           0 < (g = Ds(r, b)).length &&
             ((b = new cu(b, e, null, n, o)),
@@ -5726,7 +5726,7 @@
             : (function (e, t) {
                 if (Ru)
                   return 'compositionend' === e || (!Du && Tu(e, t))
-                    ? ((e = $l()), (Bl = Vl = Hl = null), (Ru = !1), e)
+                    ? ((e = $l()), (Bl = Vl = Wl = null), (Ru = !1), e)
                     : null
                 switch (e) {
                   case 'paste':
@@ -5849,13 +5849,13 @@
   var Fs = Math.random().toString(36).slice(2),
     Is = '__reactFiber$' + Fs,
     Us = '__reactProps$' + Fs,
-    Ws = '__reactContainer$' + Fs,
-    Hs = '__reactEvents$' + Fs
+    Hs = '__reactContainer$' + Fs,
+    Ws = '__reactEvents$' + Fs
   function Vs(e) {
     var t = e[Is]
     if (t) return t
     for (var n = e.parentNode; n; ) {
-      if ((t = n[Ws] || n[Is])) {
+      if ((t = n[Hs] || n[Is])) {
         if (
           ((n = t.alternate),
           null !== t.child || (null !== n && null !== n.child))
@@ -5871,7 +5871,7 @@
     return null
   }
   function Bs(e) {
-    return !(e = e[Is] || e[Ws]) ||
+    return !(e = e[Is] || e[Hs]) ||
       (5 !== e.tag && 6 !== e.tag && 13 !== e.tag && 3 !== e.tag)
       ? null
       : e
@@ -5884,8 +5884,8 @@
     return e[Us] || null
   }
   function qs(e) {
-    var t = e[Hs]
-    return void 0 === t && (t = e[Hs] = new Set()), t
+    var t = e[Ws]
+    return void 0 === t && (t = e[Ws] = new Set()), t
   }
   var Ks = [],
     Qs = -1
@@ -6063,10 +6063,10 @@
   }
   var Ic = Xs(null),
     Uc = null,
-    Wc = null,
-    Hc = null
+    Hc = null,
+    Wc = null
   function Vc() {
-    Hc = Wc = Uc = null
+    Wc = Hc = Uc = null
   }
   function Bc(e) {
     var t = Ic.current
@@ -6084,23 +6084,23 @@
   }
   function Yc(e, t) {
     ;(Uc = e),
-      (Hc = Wc = null),
+      (Wc = Hc = null),
       null !== (e = e.dependencies) &&
         null !== e.firstContext &&
         (0 != (e.lanes & t) && (Dd = !0), (e.firstContext = null))
   }
   function qc(e, t) {
-    if (Hc !== e && !1 !== t && 0 !== t)
+    if (Wc !== e && !1 !== t && 0 !== t)
       if (
         (('number' == typeof t && 1073741823 !== t) ||
-          ((Hc = e), (t = 1073741823)),
+          ((Wc = e), (t = 1073741823)),
         (t = { context: e, observedBits: t, next: null }),
-        null === Wc)
+        null === Hc)
       ) {
         if (null === Uc) throw Error(Ko(308))
-        ;(Wc = t),
+        ;(Hc = t),
           (Uc.dependencies = { lanes: 0, firstContext: t, responders: null })
-      } else Wc = Wc.next = t
+      } else Hc = Hc.next = t
     return e._currentValue
   }
   var Kc = !1
@@ -6878,8 +6878,8 @@
   var Ff = sa.ReactCurrentDispatcher,
     If = sa.ReactCurrentBatchConfig,
     Uf = 0,
-    Wf = null,
     Hf = null,
+    Wf = null,
     Vf = null,
     Bf = !1,
     $f = !1
@@ -6895,7 +6895,7 @@
   function Kf(e, t, n, r, o, a) {
     if (
       ((Uf = a),
-      (Wf = t),
+      (Hf = t),
       (t.memoizedState = null),
       (t.updateQueue = null),
       (t.lanes = 0),
@@ -6907,7 +6907,7 @@
       do {
         if ((($f = !1), !(25 > a))) throw Error(Ko(301))
         ;(a += 1),
-          (Vf = Hf = null),
+          (Vf = Wf = null),
           (t.updateQueue = null),
           (Ff.current = Ed),
           (e = n(r, o))
@@ -6915,9 +6915,9 @@
     }
     if (
       ((Ff.current = bd),
-      (t = null !== Hf && null !== Hf.next),
+      (t = null !== Wf && null !== Wf.next),
       (Uf = 0),
-      (Vf = Hf = Wf = null),
+      (Vf = Wf = Hf = null),
       (Bf = !1),
       t)
     )
@@ -6932,25 +6932,25 @@
       queue: null,
       next: null,
     }
-    return null === Vf ? (Wf.memoizedState = Vf = e) : (Vf = Vf.next = e), Vf
+    return null === Vf ? (Hf.memoizedState = Vf = e) : (Vf = Vf.next = e), Vf
   }
   function Xf() {
-    if (null === Hf) {
-      var e = Wf.alternate
+    if (null === Wf) {
+      var e = Hf.alternate
       e = null !== e ? e.memoizedState : null
-    } else e = Hf.next
-    var t = null === Vf ? Wf.memoizedState : Vf.next
-    if (null !== t) (Vf = t), (Hf = e)
+    } else e = Wf.next
+    var t = null === Vf ? Hf.memoizedState : Vf.next
+    if (null !== t) (Vf = t), (Wf = e)
     else {
       if (null === e) throw Error(Ko(310))
       ;(e = {
-        memoizedState: (Hf = e).memoizedState,
-        baseState: Hf.baseState,
-        baseQueue: Hf.baseQueue,
-        queue: Hf.queue,
+        memoizedState: (Wf = e).memoizedState,
+        baseState: Wf.baseState,
+        baseQueue: Wf.baseQueue,
+        queue: Wf.queue,
         next: null,
       }),
-        null === Vf ? (Wf.memoizedState = Vf = e) : (Vf = Vf.next = e)
+        null === Vf ? (Hf.memoizedState = Vf = e) : (Vf = Vf.next = e)
     }
     return Vf
   }
@@ -6962,7 +6962,7 @@
       n = t.queue
     if (null === n) throw Error(Ko(311))
     n.lastRenderedReducer = e
-    var r = Hf,
+    var r = Wf,
       o = r.baseQueue,
       a = n.pending
     if (null !== a) {
@@ -6998,7 +6998,7 @@
             next: null,
           }
           null === l ? ((i = l = c), (a = r)) : (l = l.next = c),
-            (Wf.lanes |= s),
+            (Hf.lanes |= s),
             (Mp |= s)
         }
         u = u.next
@@ -7065,7 +7065,7 @@
       p = d.getSnapshot,
       v = f.source
     f = f.subscribe
-    var h = Wf
+    var h = Hf
     return (
       (e.memoizedState = { refs: d, source: t, subscribe: r }),
       l.useEffect(
@@ -7112,7 +7112,7 @@
           lastRenderedReducer: Gf,
           lastRenderedState: c,
         }).dispatch = s =
-          yd.bind(null, Wf, e)),
+          yd.bind(null, Hf, e)),
         (u.queue = e),
         (u.baseQueue = null),
         (c = ed(o, t, n)),
@@ -7135,16 +7135,16 @@
           lastRenderedReducer: Gf,
           lastRenderedState: e,
         }).dispatch =
-        yd.bind(null, Wf, e)),
+        yd.bind(null, Hf, e)),
       [t.memoizedState, e]
     )
   }
   function od(e, t, n, r) {
     return (
       (e = { tag: e, create: t, destroy: n, deps: r, next: null }),
-      null === (t = Wf.updateQueue)
+      null === (t = Hf.updateQueue)
         ? ((t = { lastEffect: null }),
-          (Wf.updateQueue = t),
+          (Hf.updateQueue = t),
           (t.lastEffect = e.next = e))
         : null === (n = t.lastEffect)
         ? (t.lastEffect = e.next = e)
@@ -7160,19 +7160,19 @@
   }
   function ld(e, t, n, r) {
     var o = Qf()
-    ;(Wf.flags |= e),
+    ;(Hf.flags |= e),
       (o.memoizedState = od(1 | t, n, void 0, void 0 === r ? null : r))
   }
   function ud(e, t, n, r) {
     var o = Xf()
     r = void 0 === r ? null : r
     var a = void 0
-    if (null !== Hf) {
-      var i = Hf.memoizedState
+    if (null !== Wf) {
+      var i = Wf.memoizedState
       if (((a = i.destroy), null !== r && qf(r, i.deps)))
         return void od(t, n, a, r)
     }
-    ;(Wf.flags |= e), (o.memoizedState = od(1 | t, n, a, r))
+    ;(Hf.flags |= e), (o.memoizedState = od(1 | t, n, a, r))
   }
   function sd(e, t) {
     return ld(516, 4, e, t)
@@ -7250,7 +7250,7 @@
       (null === i ? (a.next = a) : ((a.next = i.next), (i.next = a)),
       (t.pending = a),
       (i = e.alternate),
-      e === Wf || (null !== i && i === Wf))
+      e === Hf || (null !== i && i === Hf))
     )
       $f = Bf = !0
     else {
@@ -7322,7 +7322,7 @@
               lastRenderedReducer: e,
               lastRenderedState: t,
             }).dispatch =
-            yd.bind(null, Wf, e)),
+            yd.bind(null, Hf, e)),
           [r.memoizedState, e]
         )
       },
@@ -7377,8 +7377,8 @@
             }),
             n = rd(t)[1]
           return (
-            0 == (2 & Wf.mode) &&
-              ((Wf.flags |= 516),
+            0 == (2 & Hf.mode) &&
+              ((Hf.flags |= 516),
               od(
                 5,
                 function () {
@@ -7753,7 +7753,7 @@
               (t.child = n)))
         : (e.memoizedState,
           i
-            ? ((o = Hd(e, t, o.children, o.fallback, n)),
+            ? ((o = Wd(e, t, o.children, o.fallback, n)),
               (i = t.child),
               (a = e.child.memoizedState),
               (i.memoizedState =
@@ -7761,7 +7761,7 @@
               (i.childLanes = e.childLanes & ~n),
               (t.memoizedState = Fd),
               o)
-            : ((n = Wd(e, t, o.children, n)), (t.memoizedState = null), n))
+            : ((n = Hd(e, t, o.children, n)), (t.memoizedState = null), n))
     )
   }
   function Ud(e, t, n, r) {
@@ -7780,7 +7780,7 @@
       n
     )
   }
-  function Wd(e, t, n, r) {
+  function Hd(e, t, n, r) {
     var o = e.child
     return (
       (e = o.sibling),
@@ -7795,7 +7795,7 @@
       (t.child = n)
     )
   }
-  function Hd(e, t, n, r, o) {
+  function Wd(e, t, n, r, o) {
     var a = t.mode,
       i = e.child
     e = i.sibling
@@ -8004,7 +8004,7 @@
                 gs('toggle', r)
                 break
               case 'input':
-                Ha(r, a), gs('invalid', r)
+                Wa(r, a), gs('invalid', r)
                 break
               case 'select':
                 ;(r._wrapperState = { wasMultiple: !!a.multiple }),
@@ -8090,7 +8090,7 @@
                 gs('toggle', e), (o = r)
                 break
               case 'input':
-                Ha(e, r), (o = Wa(e, r)), gs('invalid', e)
+                Wa(e, r), (o = Ha(e, r)), gs('invalid', e)
                 break
               case 'option':
                 o = qa(e, r)
@@ -8382,7 +8382,7 @@
           i = null
         switch (n) {
           case 'input':
-            ;(o = Wa(e, o)), (r = Wa(e, r)), (i = [])
+            ;(o = Ha(e, o)), (r = Ha(e, r)), (i = [])
             break
           case 'option':
             ;(o = qa(e, o)), (r = qa(e, r)), (i = [])
@@ -8977,8 +8977,8 @@
     Fp = null,
     Ip = null,
     Up = !1,
-    Wp = null,
-    Hp = 90,
+    Hp = null,
+    Wp = 90,
     Vp = [],
     Bp = [],
     $p = null,
@@ -9318,7 +9318,7 @@
       var n = kp
       try {
         if ((Vc(), (Ff.current = bd), Bf)) {
-          for (var r = Wf.memoizedState; null !== r; ) {
+          for (var r = Hf.memoizedState; null !== r; ) {
             var o = r.queue
             null !== o && (o.pending = null), (r = r.next)
           }
@@ -9326,7 +9326,7 @@
         }
         if (
           ((Uf = 0),
-          (Vf = Hf = Wf = null),
+          (Vf = Wf = Hf = null),
           ($f = !1),
           (yp.current = null),
           null === n || null === n.return)
@@ -9526,7 +9526,7 @@
   function wv(e, t) {
     do {
       Ev()
-    } while (null !== Wp)
+    } while (null !== Hp)
     if (0 != (48 & bp)) throw Error(Ko(327))
     var n = e.finishedWork
     if (null === n) return null
@@ -9738,7 +9738,7 @@
       } while (null !== jp)
       ;(jp = null), _c(), (bp = o)
     } else e.current = n
-    if (Up) (Up = !1), (Wp = e), (Hp = t)
+    if (Up) (Up = !1), (Hp = e), (Wp = t)
     else
       for (jp = r; null !== jp; )
         (t = jp.nextEffect),
@@ -9763,8 +9763,8 @@
       Jp ||
         null === Gp ||
         (0 != (8 & jp.flags)
-          ? Hi(jp, Gp) && (Jp = !0)
-          : 13 === jp.tag && hp(e, jp) && Hi(jp, Gp) && (Jp = !0))
+          ? Wi(jp, Gp) && (Jp = !0)
+          : 13 === jp.tag && hp(e, jp) && Wi(jp, Gp) && (Jp = !0))
       var t = jp.flags
       0 != (256 & t) && rp(e, jp),
         0 == (512 & t) ||
@@ -9777,9 +9777,9 @@
     }
   }
   function Ev() {
-    if (90 !== Hp) {
-      var e = 97 < Hp ? 97 : Hp
-      return (Hp = 90), Nc(e, _v)
+    if (90 !== Wp) {
+      var e = 97 < Wp ? 97 : Wp
+      return (Wp = 90), Nc(e, _v)
     }
     return !1
   }
@@ -9800,9 +9800,9 @@
         }))
   }
   function _v() {
-    if (null === Wp) return !1
-    var e = Wp
-    if (((Wp = null), 0 != (48 & bp))) throw Error(Ko(331))
+    if (null === Hp) return !1
+    var e = Hp
+    if (((Hp = null), 0 != (48 & bp))) throw Error(Ko(331))
     var t = bp
     bp |= 32
     var n = Bp
@@ -10076,7 +10076,7 @@
       implementation: n,
     }
   }
-  function Wv(e, t, n, r) {
+  function Hv(e, t, n, r) {
     var o = t.current,
       a = Zp(),
       i = ev(o)
@@ -10118,7 +10118,7 @@
       i
     )
   }
-  function Hv(e) {
+  function Wv(e) {
     return (e = e.current).child ? (e.child.tag, e.child.stateNode) : null
   }
   function Vv(e, t) {
@@ -10142,7 +10142,7 @@
       (n.current = t),
       (t.stateNode = n),
       Qc(t),
-      (e[Ws] = n.current),
+      (e[Hs] = n.current),
       bs(8 === e.nodeType ? e.parentNode : e),
       r)
     )
@@ -10171,11 +10171,11 @@
       if ('function' == typeof o) {
         var l = o
         o = function () {
-          var e = Hv(i)
+          var e = Wv(i)
           l.call(e)
         }
       }
-      Wv(t, i, e, o)
+      Hv(t, i, e, o)
     } else {
       if (
         ((a = n._reactRootContainer =
@@ -10201,15 +10201,15 @@
       ) {
         var u = o
         o = function () {
-          var e = Hv(i)
+          var e = Wv(i)
           u.call(e)
         }
       }
       uv(function () {
-        Wv(t, i, e, o)
+        Hv(t, i, e, o)
       })
     }
-    return Hv(i)
+    return Wv(i)
   }
   function Kv(e, t) {
     var n =
@@ -10520,13 +10520,13 @@
     throw Error(Ko(156, t.tag))
   }),
     ($v.prototype.render = function (e) {
-      Wv(e, this._internalRoot, null, null)
+      Hv(e, this._internalRoot, null, null)
     }),
     ($v.prototype.unmount = function () {
       var e = this._internalRoot,
         t = e.containerInfo
-      Wv(null, e, null, function () {
-        t[Ws] = null
+      Hv(null, e, null, function () {
+        t[Hs] = null
       })
     }),
     (Vi = function (e) {
@@ -10629,7 +10629,7 @@
       scheduleUpdate: null,
       currentDispatcherRef: sa.ReactCurrentDispatcher,
       findHostInstanceByFiber: function (e) {
-        return null === (e = Wi(e)) ? null : e.stateNode
+        return null === (e = Hi(e)) ? null : e.stateNode
       },
       findFiberByHostInstance:
         Xv.findFiberByHostInstance ||
@@ -10649,9 +10649,9 @@
         ;(cc = Jv.inject(Gv)), (fc = Jv)
       } catch (oi) {}
   }
-  ;(Wo.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = Qv),
-    (Wo.createPortal = Kv),
-    (Wo.findDOMNode = function (e) {
+  ;(Ho.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = Qv),
+    (Ho.createPortal = Kv),
+    (Ho.findDOMNode = function (e) {
       if (null == e) return null
       if (1 === e.nodeType) return e
       var t = e._reactInternals
@@ -10659,9 +10659,9 @@
         if ('function' == typeof e.render) throw Error(Ko(188))
         throw Error(Ko(268, Object.keys(e)))
       }
-      return (e = null === (e = Wi(t)) ? null : e.stateNode)
+      return (e = null === (e = Hi(t)) ? null : e.stateNode)
     }),
-    (Wo.flushSync = function (e, t) {
+    (Ho.flushSync = function (e, t) {
       var n = bp
       if (0 != (48 & n)) return e(t)
       bp |= 1
@@ -10671,40 +10671,40 @@
         ;(bp = n), Lc()
       }
     }),
-    (Wo.hydrate = function (e, t, n) {
+    (Ho.hydrate = function (e, t, n) {
       if (!Yv(t)) throw Error(Ko(200))
       return qv(null, e, t, !0, n)
     }),
-    (Wo.render = function (e, t, n) {
+    (Ho.render = function (e, t, n) {
       if (!Yv(t)) throw Error(Ko(200))
       return qv(null, e, t, !1, n)
     }),
-    (Wo.unmountComponentAtNode = function (e) {
+    (Ho.unmountComponentAtNode = function (e) {
       if (!Yv(e)) throw Error(Ko(40))
       return (
         !!e._reactRootContainer &&
         (uv(function () {
           qv(null, null, e, !1, function () {
-            ;(e._reactRootContainer = null), (e[Ws] = null)
+            ;(e._reactRootContainer = null), (e[Hs] = null)
           })
         }),
         !0)
       )
     }),
-    (Wo.unstable_batchedUpdates = lv),
-    (Wo.unstable_createPortal = function (e, t) {
+    (Ho.unstable_batchedUpdates = lv),
+    (Ho.unstable_createPortal = function (e, t) {
       return Kv(
         e,
         t,
         2 < arguments.length && void 0 !== arguments[2] ? arguments[2] : null
       )
     }),
-    (Wo.unstable_renderSubtreeIntoContainer = function (e, t, n, r) {
+    (Ho.unstable_renderSubtreeIntoContainer = function (e, t, n, r) {
       if (!Yv(n)) throw Error(Ko(200))
       if (null == e || void 0 === e._reactInternals) throw Error(Ko(38))
       return qv(e, t, n, !1, r)
     }),
-    (Wo.version = '17.0.2'),
+    (Ho.version = '17.0.2'),
     (function (e) {
       !(function e() {
         if (
@@ -10717,11 +10717,11 @@
             console.error(e)
           }
       })(),
-        (e.exports = Wo)
+        (e.exports = Ho)
     })(Uo)
   var Zv = D(Io)
   var eh = function (e) {
-      return Wn(
+      return Hn(
         (function (e) {
           return e && 'setState' in e ? Zv.findDOMNode(e) : null != e ? e : null
         })(e)
@@ -10822,7 +10822,7 @@
     return 'undefined' == typeof document
       ? null
       : null == e
-      ? Wn().body
+      ? Hn().body
       : ('function' == typeof e && (e = e()),
         e && 'current' in e && (e = e.current),
         (null != (t = e) && t.nodeType && e) || null)
@@ -11101,7 +11101,7 @@
       !U)
     )
       return null
-    var W = e.children(
+    var H = e.children(
       ce({}, O, {
         show: !!e.show,
         props: ce({}, x.popper, { style: D.popper, ref: g }),
@@ -11109,17 +11109,17 @@
       })
     )
     if (c) {
-      var H = e.onExit,
+      var W = e.onExit,
         V = e.onExiting,
         B = e.onEnter,
         $ = e.onEntering,
         Y = e.onEntered
-      W = se.createElement(
+      H = se.createElement(
         c,
         {
           in: e.show,
           appear: !0,
-          onExit: H,
+          onExit: W,
           onExiting: V,
           onExited: function () {
             E(!0), e.onExited && e.onExited.apply(e, arguments)
@@ -11128,10 +11128,10 @@
           onEntering: $,
           onEntered: Y,
         },
-        W
+        H
       )
     }
-    return y ? Zv.createPortal(W, y) : null
+    return y ? Zv.createPortal(H, y) : null
   })
   ;(fh.displayName = 'Overlay'),
     (fh.propTypes = {
@@ -11340,7 +11340,7 @@
     Lh = function (e) {
       return this.__data__.has(e)
     },
-    jh = Wt['__core-js_shared__'],
+    jh = Ht['__core-js_shared__'],
     Ah = (zh = /[^.]+$/.exec((jh && jh.keys && jh.keys.IE_PROTO) || ''))
       ? 'Symbol(src)_1.' + zh
       : ''
@@ -11359,8 +11359,8 @@
       }
       return ''
     },
-    Wh = rn,
-    Hh = Fh,
+    Hh = rn,
+    Wh = Fh,
     Vh = en,
     Bh = Uh,
     $h = /^\[object .+?Constructor\]$/,
@@ -11379,7 +11379,7 @@
         '$'
     )
   var Gh = function (e) {
-      return !(!Vh(e) || Hh(e)) && (Wh(e) ? Xh : $h).test(Bh(e))
+      return !(!Vh(e) || Wh(e)) && (Hh(e) ? Xh : $h).test(Bh(e))
     },
     Jh = function (e, t) {
       return null == e ? void 0 : e[t]
@@ -11388,7 +11388,7 @@
       var n = Jh(e, t)
       return Gh(n) ? n : void 0
     },
-    em = Zh(Wt, 'Map'),
+    em = Zh(Ht, 'Map'),
     tm = Zh(Object, 'create'),
     nm = tm
   var rm = function () {
@@ -11501,8 +11501,8 @@
     Fm = Ph,
     Im = Rh,
     Um = Nh,
-    Wm = Lh,
-    Hm = function (e, t) {
+    Hm = Lh,
+    Wm = function (e, t) {
       var n = this.__data__
       if (n instanceof zm) {
         var r = n.__data__
@@ -11519,8 +11519,8 @@
   ;(Vm.prototype.clear = Fm),
     (Vm.prototype.delete = Im),
     (Vm.prototype.get = Um),
-    (Vm.prototype.has = Wm),
-    (Vm.prototype.set = Hm)
+    (Vm.prototype.has = Hm),
+    (Vm.prototype.set = Wm)
   var Bm = Vm
   var $m = Nm,
     Ym = function (e) {
@@ -11580,7 +11580,7 @@
       }
       return a.delete(e), a.delete(t), d
     },
-    Zm = Wt.Uint8Array
+    Zm = Ht.Uint8Array
   var eg = Zm,
     tg = At,
     ng = Jm,
@@ -11604,7 +11604,7 @@
         n
       )
     },
-    ag = Ht ? Ht.prototype : void 0,
+    ag = Wt ? Wt.prototype : void 0,
     ig = ag ? ag.valueOf : void 0
   var lg = function (e, t, n, r, o, a, i) {
     switch (n) {
@@ -11708,7 +11708,7 @@
     return !1
   }
   !(function (e, t) {
-    var n = Wt,
+    var n = Ht,
       r = Pg,
       o = t && !t.nodeType && t,
       a = o && e && !e.nodeType && e,
@@ -11777,9 +11777,9 @@
     e.exports = i
   })(Ig, Fg)
   var Ug = jg,
-    Wg = Ag,
-    Hg = Fg && Fg.isTypedArray,
-    Vg = Hg ? Wg(Hg) : Ug,
+    Hg = Ag,
+    Wg = Fg && Fg.isTypedArray,
+    Vg = Wg ? Hg(Wg) : Ug,
     Bg = bg,
     $g = Mg,
     Yg = sg,
@@ -11877,11 +11877,11 @@
       }
       return a.delete(e), a.delete(t), p
     },
-    my = Zh(Wt, 'DataView'),
+    my = Zh(Ht, 'DataView'),
     gy = em,
-    yy = Zh(Wt, 'Promise'),
-    by = Zh(Wt, 'Set'),
-    wy = Zh(Wt, 'WeakMap'),
+    yy = Zh(Ht, 'Promise'),
+    by = Zh(Ht, 'Set'),
+    wy = Zh(Ht, 'WeakMap'),
     ky = Zt,
     Ey = Uh,
     Sy = '[object Map]',
@@ -11926,8 +11926,8 @@
     Fy = hy,
     Iy = zy,
     Uy = sg,
-    Wy = Cg,
-    Hy = Vg,
+    Hy = Cg,
+    Wy = Vg,
     Vy = '[object Arguments]',
     By = '[object Array]',
     $y = '[object Object]',
@@ -11940,14 +11940,14 @@
         c = (u = u == Vy ? $y : u) == $y,
         f = (s = s == Vy ? $y : s) == $y,
         d = u == s
-      if (d && Wy(e)) {
-        if (!Wy(t)) return !1
+      if (d && Hy(e)) {
+        if (!Hy(t)) return !1
         ;(i = !0), (c = !1)
       }
       if (d && !c)
         return (
           a || (a = new Ly()),
-          i || Hy(e) ? jy(e, t, n, r, o, a) : Ay(e, t, u, n, r, o, a)
+          i || Wy(e) ? jy(e, t, n, r, o, a) : Ay(e, t, u, n, r, o, a)
         )
       if (!(1 & n)) {
         var p = c && Yy.call(e, '__wrapped__'),
@@ -12271,7 +12271,9 @@
         a = n.longPressThreshold,
         i = void 0 === a ? 250 : a,
         l = n.validContainers,
-        u = void 0 === l ? [] : l
+        u = void 0 === l ? [] : l,
+        c = n.targetHostMarker,
+        f = void 0 === c ? null : c
       s(this, e),
         (this.isDetached = !1),
         (this.container = t),
@@ -12279,7 +12281,7 @@
         (this.longPressThreshold = i),
         (this.validContainers = u),
         (this._listeners = Object.create(null)),
-        (this._targetHost = ub(this.container)),
+        (this._targetHost = ub(f || this.container())),
         (this._handleInitialEvent = this._handleInitialEvent.bind(this)),
         (this._handleMoveEvent = this._handleMoveEvent.bind(this)),
         (this._handleTerminatingEvent =
@@ -12824,6 +12826,7 @@
                 t = this.containerRef.current,
                 n = (this._selector = new pb(this.props.container, {
                   longPressThreshold: this.props.longPressThreshold,
+                  targetHostMarker: this.containerRef.current,
                 })),
                 r = function (n, r) {
                   if (!cb(t, n) && !fb(t, n)) {
@@ -13146,12 +13149,12 @@
     return (n.cache = new (Ub.Cache || Ib)()), n
   }
   Ub.Cache = Ib
-  var Wb = Ub
-  var Hb =
+  var Hb = Ub
+  var Wb =
       /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g,
     Vb = /\\(\\)?/g,
     Bb = (function (e) {
-      var t = Wb(e, function (e) {
+      var t = Hb(e, function (e) {
           return 500 === n.size && n.clear(), e
         }),
         n = t.cache
@@ -13160,7 +13163,7 @@
       var t = []
       return (
         46 === e.charCodeAt(0) && t.push(''),
-        e.replace(Hb, function (e, n, r, o) {
+        e.replace(Wb, function (e, n, r, o) {
           t.push(r ? o.replace(Vb, '$1') : n || e)
         }),
         t
@@ -13174,7 +13177,7 @@
     Yb = $b,
     qb = sg,
     Kb = En,
-    Qb = Ht ? Ht.prototype : void 0,
+    Qb = Wt ? Wt.prototype : void 0,
     Xb = Qb ? Qb.toString : void 0
   var Gb = function e(t) {
       if ('string' == typeof t) return t
@@ -13286,13 +13289,13 @@
     Fw = jw,
     Iw = zn,
     Uw = Math.max
-  var Ww = function (e, t, n) {
+  var Hw = function (e, t, n) {
     var r = null == e ? 0 : e.length
     if (!r) return -1
     var o = null == n ? 0 : Iw(n)
     return o < 0 && (o = Uw(r + o, 0)), Aw(e, Fw(t), o)
   }
-  function Hw(e) {
+  function Ww(e) {
     var t = e.dateRange,
       n = e.unit,
       r = void 0 === n ? 'day' : n,
@@ -13502,18 +13505,18 @@
           o = e.minRows,
           a = e.accessors,
           l = e.localizer,
-          u = Hw({ dateRange: t, localizer: l }),
+          u = Ww({ dateRange: t, localizer: l }),
           s = u.first,
           c = u.last,
           f = n.map(function (e) {
             return (function (e, t, n, r) {
-              var o = Hw({ dateRange: t, localizer: r }),
+              var o = Ww({ dateRange: t, localizer: r }),
                 a = o.first,
                 i = o.last,
                 l = r.diff(a, i, 'day'),
                 u = r.max(r.startOf(n.start(e), 'day'), a),
                 s = r.min(r.ceil(n.end(e), 'day'), i),
-                c = Ww(t, function (e) {
+                c = Hw(t, function (e) {
                   return r.isSameDate(e, u)
                 }),
                 f = r.diff(u, s, 'day')
@@ -13794,31 +13797,33 @@
   })(se.Component)
   ck.defaultProps = { minRows: 0, maxRows: 1 / 0 }
   var fk = function (e) {
-      var t = e.label
-      return se.createElement(
-        'span',
-        { role: 'columnheader', 'aria-sort': 'none' },
-        t
-      )
-    },
-    dk = function (e) {
-      var t = e.label,
-        n = e.drilldownView,
-        r = e.onDrillDown
-      return n
-        ? se.createElement(
-            'button',
-            {
-              type: 'button',
-              className: 'rbc-button-link',
-              onClick: r,
-              role: 'cell',
-            },
-            t
-          )
-        : se.createElement('span', null, t)
-    },
-    pk = ['date', 'className'],
+    var t = e.label
+    return se.createElement(
+      'span',
+      { role: 'columnheader', 'aria-sort': 'none' },
+      t
+    )
+  }
+  fk.propTypes = {}
+  var dk = function (e) {
+    var t = e.label,
+      n = e.drilldownView,
+      r = e.onDrillDown
+    return n
+      ? se.createElement(
+          'button',
+          {
+            type: 'button',
+            className: 'rbc-button-link',
+            onClick: r,
+            role: 'cell',
+          },
+          t
+        )
+      : se.createElement('span', null, t)
+  }
+  dk.propTypes = {}
+  var pk = ['date', 'className'],
     vk = function (e, t, n, r, o) {
       return e.filter(function (e) {
         return Bw(e, t, n, r, o)
@@ -14414,7 +14419,7 @@
     })(_.Component),
     kk = Mg,
     Ek = sg,
-    Sk = Ht ? Ht.isConcatSpreadable : void 0
+    Sk = Wt ? Wt.isConcatSpreadable : void 0
   var Dk = ug,
     _k = function (e) {
       return Ek(e) || kk(e) || !!(Sk && e && e[Sk])
@@ -14508,7 +14513,7 @@
       return e
     },
     Uk = Ag,
-    Wk = function (e, t, n) {
+    Hk = function (e, t, n) {
       for (
         var r = -1, o = e.criteria, a = t.criteria, i = o.length, l = n.length;
         ++r < i;
@@ -14519,7 +14524,7 @@
       }
       return e.index - t.index
     },
-    Hk = _w,
+    Wk = _w,
     Vk = sg
   var Bk = function (e, t, n) {
     t = t.length
@@ -14530,7 +14535,7 @@
               }
             : e
         })
-      : [Hk]
+      : [Wk]
     var r = -1
     t = Lk(t, Uk(Ak))
     var o = Fk(e, function (e, n, o) {
@@ -14543,7 +14548,7 @@
       }
     })
     return Ik(o, function (e, t) {
-      return Wk(e, t, n)
+      return Hk(e, t, n)
     })
   }
   var $k = function (e, t, n) {
@@ -14965,7 +14970,10 @@
                 function () {
                   return t
                 },
-                { longPressThreshold: r }
+                {
+                  longPressThreshold: r,
+                  targetHostMarker: e.containerRef.current,
+                }
               )),
               l = function (t) {
                 var n = e.props.onSelecting,
@@ -15356,228 +15364,227 @@
     _E = function (e) {
       var t = e.label
       return se.createElement(se.Fragment, null, t)
-    },
-    xE = (function (e) {
-      p(n, e)
-      var t = g(n)
-      function n() {
-        var e
-        s(this, n)
-        for (var r = arguments.length, o = new Array(r), a = 0; a < r; a++)
-          o[a] = arguments[a]
-        return (
-          ((e = t.call.apply(t, [this].concat(o))).handleHeaderClick =
-            function (t, n, r) {
-              r.preventDefault(), Oe(e.props.onDrillDown, [t, n])
-            }),
-          (e.renderRow = function (t) {
-            var n = e.props,
-              r = n.events,
-              o = n.rtl,
-              a = n.selectable,
-              i = n.getNow,
-              l = n.range,
-              u = n.getters,
-              s = n.localizer,
-              c = n.accessors,
-              f = n.components,
-              d = n.resizable,
-              p = c.resourceId(t),
-              v = t
-                ? r.filter(function (e) {
-                    return c.resource(e) === p
-                  })
-                : r
-            return se.createElement(ck, {
-              isAllDay: !0,
-              rtl: o,
-              getNow: i,
-              minRows: 2,
-              maxRows: e.props.allDayMaxRows + 1,
-              range: l,
-              events: v,
-              resourceId: p,
-              className: 'rbc-allday-cell',
-              selectable: a,
-              selected: e.props.selected,
-              components: f,
-              accessors: c,
-              getters: u,
-              localizer: s,
-              onSelect: e.props.onSelectEvent,
-              onShowMore: e.props.onShowMore,
-              onDoubleClick: e.props.onDoubleClickEvent,
-              onKeyPress: e.props.onKeyPressEvent,
-              onSelectSlot: e.props.onSelectSlot,
-              longPressThreshold: e.props.longPressThreshold,
-              resizable: d,
-            })
-          }),
-          e
-        )
-      }
+    }
+  _E.propTypes = {}
+  var xE = (function (e) {
+    p(n, e)
+    var t = g(n)
+    function n() {
+      var e
+      s(this, n)
+      for (var r = arguments.length, o = new Array(r), a = 0; a < r; a++)
+        o[a] = arguments[a]
       return (
-        f(n, [
-          {
-            key: 'renderHeaderCells',
-            value: function (e) {
-              var t = this,
-                n = this.props,
-                r = n.localizer,
-                o = n.getDrilldownView,
-                a = n.getNow,
-                i = n.getters.dayProp,
-                l = n.components.header,
-                u = void 0 === l ? fk : l,
-                s = a()
-              return e.map(function (e, n) {
-                var a = o(e),
-                  l = r.format(e, 'dayFormat'),
-                  c = i(e),
-                  f = c.className,
-                  d = c.style,
-                  p = se.createElement(u, { date: e, label: l, localizer: r })
-                return se.createElement(
-                  'div',
-                  {
-                    key: n,
-                    style: d,
-                    className: be(
-                      'rbc-header',
-                      f,
-                      r.isSameDate(e, s) && 'rbc-today'
-                    ),
-                  },
-                  a
-                    ? se.createElement(
-                        'button',
-                        {
-                          type: 'button',
-                          className: 'rbc-button-link',
-                          onClick: function (n) {
-                            return t.handleHeaderClick(e, a, n)
-                          },
-                        },
-                        p
-                      )
-                    : se.createElement('span', null, p)
-                )
-              })
-            },
-          },
-          {
-            key: 'render',
-            value: function () {
-              var e = this,
-                t = this.props,
-                n = t.width,
-                r = t.rtl,
-                o = t.resources,
-                a = t.range,
-                i = t.events,
-                l = t.getNow,
-                u = t.accessors,
-                s = t.selectable,
-                c = t.components,
-                f = t.getters,
-                d = t.scrollRef,
-                p = t.localizer,
-                v = t.isOverflowing,
-                h = t.components,
-                m = h.timeGutterHeader,
-                g = h.resourceHeader,
-                y = void 0 === g ? _E : g,
-                b = t.resizable,
-                w = {}
-              v &&
-                (w[r ? 'marginLeft' : 'marginRight'] = ''.concat(
-                  ih() - 1,
-                  'px'
-                ))
-              var k = o.groupEvents(i)
+        ((e = t.call.apply(t, [this].concat(o))).handleHeaderClick = function (
+          t,
+          n,
+          r
+        ) {
+          r.preventDefault(), Oe(e.props.onDrillDown, [t, n])
+        }),
+        (e.renderRow = function (t) {
+          var n = e.props,
+            r = n.events,
+            o = n.rtl,
+            a = n.selectable,
+            i = n.getNow,
+            l = n.range,
+            u = n.getters,
+            s = n.localizer,
+            c = n.accessors,
+            f = n.components,
+            d = n.resizable,
+            p = c.resourceId(t),
+            v = t
+              ? r.filter(function (e) {
+                  return c.resource(e) === p
+                })
+              : r
+          return se.createElement(ck, {
+            isAllDay: !0,
+            rtl: o,
+            getNow: i,
+            minRows: 2,
+            maxRows: e.props.allDayMaxRows + 1,
+            range: l,
+            events: v,
+            resourceId: p,
+            className: 'rbc-allday-cell',
+            selectable: a,
+            selected: e.props.selected,
+            components: f,
+            accessors: c,
+            getters: u,
+            localizer: s,
+            onSelect: e.props.onSelectEvent,
+            onShowMore: e.props.onShowMore,
+            onDoubleClick: e.props.onDoubleClickEvent,
+            onKeyPress: e.props.onKeyPressEvent,
+            onSelectSlot: e.props.onSelectSlot,
+            longPressThreshold: e.props.longPressThreshold,
+            resizable: d,
+          })
+        }),
+        e
+      )
+    }
+    return (
+      f(n, [
+        {
+          key: 'renderHeaderCells',
+          value: function (e) {
+            var t = this,
+              n = this.props,
+              r = n.localizer,
+              o = n.getDrilldownView,
+              a = n.getNow,
+              i = n.getters.dayProp,
+              l = n.components.header,
+              u = void 0 === l ? fk : l,
+              s = a()
+            return e.map(function (e, n) {
+              var a = o(e),
+                l = r.format(e, 'dayFormat'),
+                c = i(e),
+                f = c.className,
+                d = c.style,
+                p = se.createElement(u, { date: e, label: l, localizer: r })
               return se.createElement(
                 'div',
                 {
-                  style: w,
-                  ref: d,
-                  className: be('rbc-time-header', v && 'rbc-overflowing'),
+                  key: n,
+                  style: d,
+                  className: be(
+                    'rbc-header',
+                    f,
+                    r.isSameDate(e, s) && 'rbc-today'
+                  ),
                 },
-                se.createElement(
-                  'div',
-                  {
-                    className: 'rbc-label rbc-time-header-gutter',
-                    style: { width: n, minWidth: n, maxWidth: n },
-                  },
-                  m && se.createElement(m, null)
-                ),
-                o.map(function (t, n) {
-                  var o = E(t, 2),
-                    i = o[0],
-                    d = o[1]
-                  return se.createElement(
-                    'div',
-                    { className: 'rbc-time-header-content', key: i || n },
-                    d &&
-                      se.createElement(
-                        'div',
-                        {
-                          className: 'rbc-row rbc-row-resource',
-                          key: 'resource_'.concat(n),
+                a
+                  ? se.createElement(
+                      'button',
+                      {
+                        type: 'button',
+                        className: 'rbc-button-link',
+                        onClick: function (n) {
+                          return t.handleHeaderClick(e, a, n)
                         },
-                        se.createElement(
-                          'div',
-                          { className: 'rbc-header' },
-                          se.createElement(y, {
-                            index: n,
-                            label: u.resourceTitle(d),
-                            resource: d,
-                          })
-                        )
-                      ),
+                      },
+                      p
+                    )
+                  : se.createElement('span', null, p)
+              )
+            })
+          },
+        },
+        {
+          key: 'render',
+          value: function () {
+            var e = this,
+              t = this.props,
+              n = t.width,
+              r = t.rtl,
+              o = t.resources,
+              a = t.range,
+              i = t.events,
+              l = t.getNow,
+              u = t.accessors,
+              s = t.selectable,
+              c = t.components,
+              f = t.getters,
+              d = t.scrollRef,
+              p = t.localizer,
+              v = t.isOverflowing,
+              h = t.components,
+              m = h.timeGutterHeader,
+              g = h.resourceHeader,
+              y = void 0 === g ? _E : g,
+              b = t.resizable,
+              w = {}
+            v &&
+              (w[r ? 'marginLeft' : 'marginRight'] = ''.concat(ih() - 1, 'px'))
+            var k = o.groupEvents(i)
+            return se.createElement(
+              'div',
+              {
+                style: w,
+                ref: d,
+                className: be('rbc-time-header', v && 'rbc-overflowing'),
+              },
+              se.createElement(
+                'div',
+                {
+                  className: 'rbc-label rbc-time-header-gutter',
+                  style: { width: n, minWidth: n, maxWidth: n },
+                },
+                m && se.createElement(m, null)
+              ),
+              o.map(function (t, n) {
+                var o = E(t, 2),
+                  i = o[0],
+                  d = o[1]
+                return se.createElement(
+                  'div',
+                  { className: 'rbc-time-header-content', key: i || n },
+                  d &&
                     se.createElement(
                       'div',
                       {
-                        className: 'rbc-row rbc-time-header-cell'.concat(
-                          a.length <= 1
-                            ? ' rbc-time-header-cell-single-day'
-                            : ''
-                        ),
+                        className: 'rbc-row rbc-row-resource',
+                        key: 'resource_'.concat(n),
                       },
-                      e.renderHeaderCells(a)
+                      se.createElement(
+                        'div',
+                        { className: 'rbc-header' },
+                        se.createElement(y, {
+                          index: n,
+                          label: u.resourceTitle(d),
+                          resource: d,
+                        })
+                      )
                     ),
-                    se.createElement(ck, {
-                      isAllDay: !0,
-                      rtl: r,
-                      getNow: l,
-                      minRows: 2,
-                      maxRows: e.props.allDayMaxRows + 1,
-                      range: a,
-                      events: k.get(i) || [],
-                      resourceId: d && i,
-                      className: 'rbc-allday-cell',
-                      selectable: s,
-                      selected: e.props.selected,
-                      components: c,
-                      accessors: u,
-                      getters: f,
-                      localizer: p,
-                      onSelect: e.props.onSelectEvent,
-                      onShowMore: e.props.onShowMore,
-                      onDoubleClick: e.props.onDoubleClickEvent,
-                      onKeyPress: e.props.onKeyPressEvent,
-                      onSelectSlot: e.props.onSelectSlot,
-                      longPressThreshold: e.props.longPressThreshold,
-                      resizable: b,
-                    })
-                  )
-                })
-              )
-            },
+                  se.createElement(
+                    'div',
+                    {
+                      className: 'rbc-row rbc-time-header-cell'.concat(
+                        a.length <= 1 ? ' rbc-time-header-cell-single-day' : ''
+                      ),
+                    },
+                    e.renderHeaderCells(a)
+                  ),
+                  se.createElement(ck, {
+                    isAllDay: !0,
+                    rtl: r,
+                    getNow: l,
+                    minRows: 2,
+                    maxRows: e.props.allDayMaxRows + 1,
+                    range: a,
+                    events: k.get(i) || [],
+                    resourceId: d && i,
+                    className: 'rbc-allday-cell',
+                    selectable: s,
+                    selected: e.props.selected,
+                    components: c,
+                    accessors: u,
+                    getters: f,
+                    localizer: p,
+                    onSelect: e.props.onSelectEvent,
+                    onShowMore: e.props.onShowMore,
+                    onDoubleClick: e.props.onDoubleClickEvent,
+                    onKeyPress: e.props.onKeyPressEvent,
+                    onSelectSlot: e.props.onSelectSlot,
+                    longPressThreshold: e.props.longPressThreshold,
+                    resizable: b,
+                  })
+                )
+              })
+            )
           },
-        ]),
-        n
-      )
-    })(se.Component)
+        },
+      ]),
+      n
+    )
+  })(se.Component)
   function OE(e, t) {
     var n = Qn(e)
     return n ? n.innerWidth : t ? e.clientWidth : Zn(e).width
@@ -16460,12 +16467,12 @@
       o(AE, _e.DAY, PE),
       o(AE, _e.AGENDA, IE),
       AE),
-    WE = ['action', 'date', 'today']
-  function HE(e, t) {
+    HE = ['action', 'date', 'today']
+  function WE(e, t) {
     var n = t.action,
       r = t.date,
       o = t.today,
-      a = u(t, WE)
+      a = u(t, HE)
     switch (((e = 'string' == typeof e ? UE[e] : e), n)) {
       case De.TODAY:
         r = o || new Date()
@@ -16646,7 +16653,7 @@
       },
     }
   !(function (e, t) {
-    var n = Wt,
+    var n = Ht,
       r = t && !t.nodeType && t,
       o = r && e && !e.nodeType && e,
       a = o && o.exports === r ? n.Buffer : void 0,
@@ -16718,14 +16725,14 @@
       var t = new e.constructor(e.source, IS.exec(e))
       return (t.lastIndex = e.lastIndex), t
     },
-    WS = Ht ? Ht.prototype : void 0,
-    HS = WS ? WS.valueOf : void 0
+    HS = Wt ? Wt.prototype : void 0,
+    WS = HS ? HS.valueOf : void 0
   var VS = jS
   var BS = jS,
     $S = FS,
     YS = US,
     qS = function (e) {
-      return HS ? Object(HS.call(e)) : {}
+      return WS ? Object(WS.call(e)) : {}
     },
     KS = function (e, t) {
       var n = t ? VS(e.buffer) : e.buffer
@@ -16847,7 +16854,7 @@
     UD['[object Uint32Array]'] =
       !0),
     (UD['[object Error]'] = UD[FD] = UD['[object WeakMap]'] = !1)
-  var WD = function e(t, n, r, o, a, i) {
+  var HD = function e(t, n, r, o, a, i) {
     var l,
       u = 1 & n,
       s = 2 & n,
@@ -16889,7 +16896,7 @@
       l
     )
   }
-  var HD = uw,
+  var WD = uw,
     VD = jt
   var BD = rw,
     $D = function (e) {
@@ -16897,7 +16904,7 @@
       return t ? e[t - 1] : void 0
     },
     YD = function (e, t) {
-      return t.length < 2 ? e : HD(e, VD(t, 0, -1))
+      return t.length < 2 ? e : WD(e, VD(t, 0, -1))
     },
     qD = aw
   var KD = function (e, t) {
@@ -16925,7 +16932,7 @@
     i_ = qk,
     l_ = nE
   var u_ = $b,
-    s_ = WD,
+    s_ = HD,
     c_ = KD,
     f_ = rw,
     d_ = ZE,
@@ -17040,7 +17047,7 @@
       'messages',
       'culture',
     ]
-  function W_(e) {
+  function H_(e) {
     if (Array.isArray(e)) return e
     for (var t = [], n = 0, r = Object.entries(e); n < r.length; n++) {
       var o = E(r[n], 2),
@@ -17049,8 +17056,8 @@
     }
     return t
   }
-  function H_(e, t) {
-    return -1 !== W_(t.views).indexOf(e)
+  function W_(e, t) {
+    return -1 !== H_(t.views).indexOf(e)
   }
   var V_ = (function (e) {
     p(o, e)
@@ -17103,7 +17110,7 @@
             f = e.getView(),
             d = l()
           s(
-            (a = HE(
+            (a = WE(
               f,
               i(i({}, c), {}, { action: t, date: n || a || d, today: d })
             )),
@@ -17113,7 +17120,7 @@
             e.handleRangeChange(a, f)
         }),
         (e.handleViewChange = function (t) {
-          t !== e.props.view && H_(t, e.props) && e.props.onView(t)
+          t !== e.props.view && W_(t, e.props) && e.props.onView(t)
           var n = e.getViews()
           e.handleRangeChange(e.props.date || e.props.getNow(), n[t], t)
         }),
@@ -17255,7 +17262,7 @@
                 S = void 0 === E ? {} : E,
                 D = e.formats,
                 _ = void 0 === D ? {} : D,
-                x = W_(g)
+                x = H_(g)
               return {
                 viewNames: x,
                 localizer: Rt(
@@ -18773,7 +18780,7 @@
           o = e.fromJSDate(n)
         return r.hasSame(o, 'day')
       }
-      function W() {
+      function H() {
         var t = new Date(),
           n = /-/.test(t.toString()) ? '-' : '',
           r = t.getTimezoneOffset(),
@@ -18813,7 +18820,7 @@
         sortEvents: F,
         inEventRange: I,
         isSameDate: U,
-        browserTZOffset: W,
+        browserTZOffset: H,
       })
     }),
     (e.momentLocalizer = function (e) {
@@ -19071,5 +19078,5 @@
         },
       })
     }),
-    (e.move = HE)
+    (e.move = WE)
 })

--- a/dist/react-big-calendar.min.js
+++ b/dist/react-big-calendar.min.js
@@ -290,16 +290,16 @@
       ? e.default
       : e
   }
-  var x = {},
-    O = {
+  var _ = {},
+    x = {
       get exports() {
-        return x
+        return _
       },
       set exports(e) {
-        x = e
+        _ = e
       },
     },
-    _ = {},
+    O = {},
     M = Object.getOwnPropertySymbols,
     C = Object.prototype.hasOwnProperty,
     T = Object.prototype.propertyIsEnumerable
@@ -354,24 +354,24 @@
    *
    * This source code is licensed under the MIT license found in the
    * LICENSE file in the root directory of this source tree.
-   */ ;(_.Fragment = 60107), (_.StrictMode = 60108), (_.Profiler = 60114)
+   */ ;(O.Fragment = 60107), (O.StrictMode = 60108), (O.Profiler = 60114)
   var j = 60109,
     A = 60110,
     F = 60112
-  _.Suspense = 60113
+  O.Suspense = 60113
   var I = 60115,
     U = 60116
   if ('function' == typeof Symbol && Symbol.for) {
     var W = Symbol.for
     ;(z = W('react.element')),
       (L = W('react.portal')),
-      (_.Fragment = W('react.fragment')),
-      (_.StrictMode = W('react.strict_mode')),
-      (_.Profiler = W('react.profiler')),
+      (O.Fragment = W('react.fragment')),
+      (O.StrictMode = W('react.strict_mode')),
+      (O.Profiler = W('react.profiler')),
       (j = W('react.provider')),
       (A = W('react.context')),
       (F = W('react.forward_ref')),
-      (_.Suspense = W('react.suspense')),
+      (O.Suspense = W('react.suspense')),
       (I = W('react.memo')),
       (U = W('react.lazy'))
   }
@@ -590,7 +590,7 @@
     IsSomeRendererActing: { current: !1 },
     assign: N,
   }
-  ;(_.Children = {
+  ;(O.Children = {
     map: oe,
     forEach: function (e, t, n) {
       oe(
@@ -622,10 +622,10 @@
       return e
     },
   }),
-    (_.Component = Y),
-    (_.PureComponent = K),
-    (_.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = ue),
-    (_.cloneElement = function (e, t, n) {
+    (O.Component = Y),
+    (O.PureComponent = K),
+    (O.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = ue),
+    (O.cloneElement = function (e, t, n) {
       if (null == e) throw Error(V(267, e))
       var r = N({}, e.props),
         o = e.key,
@@ -652,7 +652,7 @@
       }
       return { $$typeof: z, type: e.type, key: o, ref: a, props: r, _owner: i }
     }),
-    (_.createContext = function (e, t) {
+    (O.createContext = function (e, t) {
       return (
         void 0 === t && (t = null),
         ((e = {
@@ -667,57 +667,57 @@
         (e.Consumer = e)
       )
     }),
-    (_.createElement = Z),
-    (_.createFactory = function (e) {
+    (O.createElement = Z),
+    (O.createFactory = function (e) {
       var t = Z.bind(null, e)
       return (t.type = e), t
     }),
-    (_.createRef = function () {
+    (O.createRef = function () {
       return { current: null }
     }),
-    (_.forwardRef = function (e) {
+    (O.forwardRef = function (e) {
       return { $$typeof: F, render: e }
     }),
-    (_.isValidElement = ee),
-    (_.lazy = function (e) {
+    (O.isValidElement = ee),
+    (O.lazy = function (e) {
       return { $$typeof: U, _payload: { _status: -1, _result: e }, _init: ae }
     }),
-    (_.memo = function (e, t) {
+    (O.memo = function (e, t) {
       return { $$typeof: I, type: e, compare: void 0 === t ? null : t }
     }),
-    (_.useCallback = function (e, t) {
+    (O.useCallback = function (e, t) {
       return le().useCallback(e, t)
     }),
-    (_.useContext = function (e, t) {
+    (O.useContext = function (e, t) {
       return le().useContext(e, t)
     }),
-    (_.useDebugValue = function () {}),
-    (_.useEffect = function (e, t) {
+    (O.useDebugValue = function () {}),
+    (O.useEffect = function (e, t) {
       return le().useEffect(e, t)
     }),
-    (_.useImperativeHandle = function (e, t, n) {
+    (O.useImperativeHandle = function (e, t, n) {
       return le().useImperativeHandle(e, t, n)
     }),
-    (_.useLayoutEffect = function (e, t) {
+    (O.useLayoutEffect = function (e, t) {
       return le().useLayoutEffect(e, t)
     }),
-    (_.useMemo = function (e, t) {
+    (O.useMemo = function (e, t) {
       return le().useMemo(e, t)
     }),
-    (_.useReducer = function (e, t, n) {
+    (O.useReducer = function (e, t, n) {
       return le().useReducer(e, t, n)
     }),
-    (_.useRef = function (e) {
+    (O.useRef = function (e) {
       return le().useRef(e)
     }),
-    (_.useState = function (e) {
+    (O.useState = function (e) {
       return le().useState(e)
     }),
-    (_.version = '17.0.2'),
+    (O.version = '17.0.2'),
     (function (e) {
-      e.exports = _
-    })(O)
-  var se = D(x)
+      e.exports = O
+    })(x)
+  var se = D(_)
   function ce() {
     return (
       (ce = Object.assign
@@ -854,26 +854,26 @@
     return (n.PropTypes = n), n
   })()
   var De = { PREVIOUS: 'PREV', NEXT: 'NEXT', TODAY: 'TODAY', DATE: 'DATE' },
-    xe = {
+    _e = {
       MONTH: 'month',
       WEEK: 'week',
       WORK_WEEK: 'work_week',
       DAY: 'day',
       AGENDA: 'agenda',
     },
-    Oe = Object.keys(xe).map(function (e) {
-      return xe[e]
+    xe = Object.keys(_e).map(function (e) {
+      return _e[e]
     })
-  function _e(e, t) {
+  function Oe(e, t) {
     e && e.apply(null, [].concat(t))
   }
   we.oneOfType([we.string, we.func]),
     we.any,
     we.func,
     we.oneOfType([
-      we.arrayOf(we.oneOf(Oe)),
+      we.arrayOf(we.oneOf(xe)),
       we.objectOf(function (e, t) {
-        var n = -1 !== Oe.indexOf(t) && 'boolean' == typeof e[t]
+        var n = -1 !== xe.indexOf(t) && 'boolean' == typeof e[t]
         if (n) return null
         for (
           var r = arguments.length, o = new Array(r > 2 ? r - 2 : 0), a = 2;
@@ -1141,13 +1141,13 @@
     var t = Ve(e, 'day')
     return yt(t, e, 'minutes') + Et(t, e)
   }
-  function xt(e, t) {
+  function _t(e, t) {
     return Qe(e, t, 'day')
   }
-  function Ot(e, t, n) {
+  function xt(e, t, n) {
     return $e(e, t, 'minutes') ? Ke(t, n, 'minutes') : qe(t, n, 'minutes')
   }
-  function _t(e) {
+  function Ot(e) {
     var t = e.evtA,
       n = t.start,
       r = t.end,
@@ -1229,9 +1229,9 @@
       (this.getDstOffset = t.getDstOffset || Et),
       (this.getTotalMin = t.getTotalMin || St),
       (this.getMinutesFromMidnight = t.getMinutesFromMidnight || Dt),
-      (this.continuesPrior = t.continuesPrior || xt),
-      (this.continuesAfter = t.continuesAfter || Ot),
-      (this.sortEvents = t.sortEvents || _t),
+      (this.continuesPrior = t.continuesPrior || _t),
+      (this.continuesAfter = t.continuesAfter || xt),
+      (this.sortEvents = t.sortEvents || Ot),
       (this.inEventRange = t.inEventRange || Mt),
       (this.isSameDate = t.isSameDate || Ct),
       (this.startAndEndAreDateOnly = t.startAndEndAreDateOnly || Tt),
@@ -1410,22 +1410,22 @@
       return e ? e.slice(0, gn(e) + 1).replace(yn, '') : e
     },
     Dn = en,
-    xn = En,
-    On = /^[-+]0x[0-9a-f]+$/i,
-    _n = /^0b[01]+$/i,
+    _n = En,
+    xn = /^[-+]0x[0-9a-f]+$/i,
+    On = /^0b[01]+$/i,
     Mn = /^0o[0-7]+$/i,
     Cn = parseInt
   var Tn = function (e) {
       if ('number' == typeof e) return e
-      if (xn(e)) return NaN
+      if (_n(e)) return NaN
       if (Dn(e)) {
         var t = 'function' == typeof e.valueOf ? e.valueOf() : e
         e = Dn(t) ? t + '' : t
       }
       if ('string' != typeof e) return 0 === e ? e : +e
       e = Sn(e)
-      var n = _n.test(e)
-      return n || Mn.test(e) ? Cn(e.slice(2), n ? 2 : 8) : On.test(e) ? NaN : +e
+      var n = On.test(e)
+      return n || Mn.test(e) ? Cn(e.slice(2), n ? 2 : 8) : xn.test(e) ? NaN : +e
     },
     Pn = 1 / 0
   var Rn = function (e) {
@@ -1639,9 +1639,9 @@
   } catch (e) {}
   function hr(e) {
     var t = (function (e) {
-      var t = x.useRef(e)
+      var t = _.useRef(e)
       return (
-        x.useEffect(
+        _.useEffect(
           function () {
             t.current = e
           },
@@ -1650,7 +1650,7 @@
         t
       )
     })(e)
-    return x.useCallback(
+    return _.useCallback(
       function () {
         return t.current && t.current.apply(t, arguments)
       },
@@ -1658,16 +1658,16 @@
     )
   }
   function mr() {
-    return x.useState(null)
+    return _.useState(null)
   }
   function gr(e) {
     var t = (function () {
-      var e = x.useRef(!0),
-        t = x.useRef(function () {
+      var e = _.useRef(!0),
+        t = _.useRef(function () {
           return e.current
         })
       return (
-        x.useEffect(function () {
+        _.useEffect(function () {
           return (
             (e.current = !0),
             function () {
@@ -1680,7 +1680,7 @@
     })()
     return [
       e[0],
-      x.useCallback(
+      _.useCallback(
         function (n) {
           if (t()) return e[1](n)
         },
@@ -1695,14 +1695,14 @@
     Er = 'auto',
     Sr = [yr, br, wr, kr],
     Dr = 'start',
-    xr = 'end',
-    Or = 'viewport',
-    _r = 'popper',
+    _r = 'end',
+    xr = 'viewport',
+    Or = 'popper',
     Mr = Sr.reduce(function (e, t) {
-      return e.concat([t + '-' + Dr, t + '-' + xr])
+      return e.concat([t + '-' + Dr, t + '-' + _r])
     }, []),
     Cr = [].concat(Sr, [Er]).reduce(function (e, t) {
-      return e.concat([t, t + '-' + Dr, t + '-' + xr])
+      return e.concat([t, t + '-' + Dr, t + '-' + _r])
     }, []),
     Tr = [
       'beforeRead',
@@ -1965,7 +1965,7 @@
           'static' !== $r((E = qr(n))).position &&
           'absolute' === l &&
           ((S = 'scrollHeight'), (D = 'scrollWidth')),
-        o === yr || ((o === kr || o === wr) && a === xr))
+        o === yr || ((o === kr || o === wr) && a === _r))
       )
         (w = br),
           (h -=
@@ -1973,16 +1973,16 @@
               ? k.visualViewport.height
               : E[S]) - r.height),
           (h *= u ? 1 : -1)
-      if (o === kr || ((o === yr || o === br) && a === xr))
+      if (o === kr || ((o === yr || o === br) && a === _r))
         (b = wr),
           (p -=
             (f && E === k && k.visualViewport ? k.visualViewport.width : E[D]) -
             r.width),
           (p *= u ? 1 : -1)
     }
-    var x,
-      O = Object.assign({ position: l }, s && ro),
-      _ =
+    var _,
+      x = Object.assign({ position: l }, s && ro),
+      O =
         !0 === c
           ? (function (e) {
               var t = e.x,
@@ -1992,23 +1992,23 @@
             })({ x: p, y: h })
           : { x: p, y: h }
     return (
-      (p = _.x),
-      (h = _.y),
+      (p = O.x),
+      (h = O.y),
       u
         ? Object.assign(
             {},
-            O,
-            (((x = {})[w] = y ? '0' : ''),
-            (x[b] = g ? '0' : ''),
-            (x.transform =
+            x,
+            (((_ = {})[w] = y ? '0' : ''),
+            (_[b] = g ? '0' : ''),
+            (_.transform =
               (k.devicePixelRatio || 1) <= 1
                 ? 'translate(' + p + 'px, ' + h + 'px)'
                 : 'translate3d(' + p + 'px, ' + h + 'px, 0)'),
-            x)
+            _)
           )
         : Object.assign(
             {},
-            O,
+            x,
             (((t = {})[w] = y ? h + 'px' : ''),
             (t[b] = g ? p + 'px' : ''),
             (t.transform = ''),
@@ -2154,7 +2154,7 @@
     })
   }
   function bo(e, t, n) {
-    return t === Or
+    return t === xr
       ? yo(
           (function (e, t) {
             var n = Rr(e),
@@ -2284,7 +2284,7 @@
         case Dr:
           t[s] = t[s] - (n[c] / 2 - r[c] / 2)
           break
-        case xr:
+        case _r:
           t[s] = t[s] + (n[c] / 2 - r[c] / 2)
       }
     }
@@ -2300,38 +2300,38 @@
       l = n.boundary,
       u = void 0 === l ? 'clippingParents' : l,
       s = n.rootBoundary,
-      c = void 0 === s ? Or : s,
+      c = void 0 === s ? xr : s,
       f = n.elementContext,
-      d = void 0 === f ? _r : f,
+      d = void 0 === f ? Or : f,
       p = n.altBoundary,
       v = void 0 !== p && p,
       h = n.padding,
       m = void 0 === h ? 0 : h,
       g = Zr('number' != typeof m ? m : eo(m, Sr)),
-      y = d === _r ? 'reference' : _r,
+      y = d === Or ? 'reference' : Or,
       b = e.rects.popper,
       w = e.elements[v ? y : d],
       k = wo(Nr(w) ? w : w.contextElement || qr(e.elements.popper), u, c, i),
       E = Wr(e.elements.reference),
       S = ko({ reference: E, element: b, strategy: 'absolute', placement: o }),
       D = yo(Object.assign({}, b, S)),
-      x = d === _r ? D : E,
-      O = {
-        top: k.top - x.top + g.top,
-        bottom: x.bottom - k.bottom + g.bottom,
-        left: k.left - x.left + g.left,
-        right: x.right - k.right + g.right,
+      _ = d === Or ? D : E,
+      x = {
+        top: k.top - _.top + g.top,
+        bottom: _.bottom - k.bottom + g.bottom,
+        left: k.left - _.left + g.left,
+        right: _.right - k.right + g.right,
       },
-      _ = e.modifiersData.offset
-    if (d === _r && _) {
-      var M = _[o]
-      Object.keys(O).forEach(function (e) {
+      O = e.modifiersData.offset
+    if (d === Or && O) {
+      var M = O[o]
+      Object.keys(x).forEach(function (e) {
         var t = [wr, br].indexOf(e) >= 0 ? 1 : -1,
           n = [yr, br].indexOf(e) >= 0 ? 'y' : 'x'
-        O[e] += M[n] * t
+        x[e] += M[n] * t
       })
     }
-    return O
+    return x
   }
   function So(e, t) {
     void 0 === t && (t = {})
@@ -2422,17 +2422,17 @@
             E = new Map(),
             S = !0,
             D = b[0],
-            x = 0;
-          x < b.length;
-          x++
+            _ = 0;
+          _ < b.length;
+          _++
         ) {
-          var O = b[x],
-            _ = Pr(O),
-            M = no(O) === Dr,
-            C = [yr, br].indexOf(_) >= 0,
+          var x = b[_],
+            O = Pr(x),
+            M = no(x) === Dr,
+            C = [yr, br].indexOf(O) >= 0,
             T = C ? 'width' : 'height',
             P = Eo(t, {
-              placement: O,
+              placement: x,
               boundary: c,
               rootBoundary: f,
               altBoundary: d,
@@ -2443,16 +2443,16 @@
           var N = so(R),
             z = []
           if (
-            (a && z.push(P[_] <= 0),
+            (a && z.push(P[O] <= 0),
             l && z.push(P[R] <= 0, P[N] <= 0),
             z.every(function (e) {
               return e
             }))
           ) {
-            ;(D = O), (S = !1)
+            ;(D = x), (S = !1)
             break
           }
-          E.set(O, z)
+          E.set(x, z)
         }
         if (S)
           for (
@@ -2479,7 +2479,7 @@
     requiresIfExists: ['offset'],
     data: { _skip: !1 },
   }
-  function xo(e, t, n) {
+  function _o(e, t, n) {
     return (
       void 0 === n && (n = { x: 0, y: 0 }),
       {
@@ -2490,12 +2490,12 @@
       }
     )
   }
-  function Oo(e) {
+  function xo(e) {
     return [yr, wr, br, kr].some(function (t) {
       return e[t] >= 0
     })
   }
-  var _o = {
+  var Oo = {
     name: 'offset',
     enabled: !0,
     phase: 'main',
@@ -2564,15 +2564,15 @@
         E = t.modifiersData.popperOffsets,
         S = t.rects.reference,
         D = t.rects.popper,
-        x =
+        _ =
           'function' == typeof h
             ? h(Object.assign({}, t.rects, { placement: t.placement }))
             : h,
-        O =
-          'number' == typeof x
-            ? { mainAxis: x, altAxis: x }
-            : Object.assign({ mainAxis: 0, altAxis: 0 }, x),
-        _ = t.modifiersData.offset ? t.modifiersData.offset[t.placement] : null,
+        x =
+          'number' == typeof _
+            ? { mainAxis: _, altAxis: _ }
+            : Object.assign({ mainAxis: 0, altAxis: 0 }, _),
+        O = t.modifiersData.offset ? t.modifiersData.offset[t.placement] : null,
         M = { x: 0, y: 0 }
       if (E) {
         if (a) {
@@ -2594,11 +2594,11 @@
             H = W[T],
             V = W[P],
             B = Jr(0, S[R], U[R]),
-            $ = b ? S[R] / 2 - j - B - H - O.mainAxis : A - B - H - O.mainAxis,
-            Y = b ? -S[R] / 2 + j + B + V + O.mainAxis : F + B + V + O.mainAxis,
+            $ = b ? S[R] / 2 - j - B - H - x.mainAxis : A - B - H - x.mainAxis,
+            Y = b ? -S[R] / 2 + j + B + V + x.mainAxis : F + B + V + x.mainAxis,
             q = t.elements.arrow && Xr(t.elements.arrow),
             K = q ? ('y' === w ? q.clientTop || 0 : q.clientLeft || 0) : 0,
-            Q = null != (C = null == _ ? void 0 : _[w]) ? C : 0,
+            Q = null != (C = null == O ? void 0 : O[w]) ? C : 0,
             X = N + Y - Q,
             G = Jr(p ? Ar(z, N + $ - Q - K) : z, N, p ? jr(L, X) : L)
           ;(E[w] = G), (M[w] = G - N)
@@ -2612,9 +2612,9 @@
             re = te + m[Z],
             oe = te - m[ee],
             ae = -1 !== [yr, kr].indexOf(g),
-            ie = null != (J = null == _ ? void 0 : _[k]) ? J : 0,
-            le = ae ? re : te - S[ne] - D[ne] - ie + O.altAxis,
-            ue = ae ? te + S[ne] + D[ne] - ie - O.altAxis : oe,
+            ie = null != (J = null == O ? void 0 : O[k]) ? J : 0,
+            le = ae ? re : te - S[ne] - D[ne] - ie + x.altAxis,
+            ue = ae ? te + S[ne] + D[ne] - ie - x.altAxis : oe,
             se =
               p && ae
                 ? (function (e, t, n) {
@@ -2864,10 +2864,10 @@
               a = t.modifiersData.preventOverflow,
               i = Eo(t, { elementContext: 'reference' }),
               l = Eo(t, { altBoundary: !0 }),
-              u = xo(i, r),
-              s = xo(l, o, a),
-              c = Oo(u),
-              f = Oo(s)
+              u = _o(i, r),
+              s = _o(l, o, a),
+              c = xo(u),
+              f = xo(s)
             ;(t.modifiersData[n] = {
               referenceClippingOffsets: u,
               popperEscapeOffsets: s,
@@ -2898,7 +2898,7 @@
         },
         ao,
         lo,
-        _o,
+        Oo,
         Do,
         Mo,
         to,
@@ -3145,29 +3145,29 @@
       var n = e.sortIndex - t.sortIndex
       return 0 !== n ? n : e.id - t.id
     }
-    var x = [],
-      O = [],
-      _ = 1,
+    var _ = [],
+      x = [],
+      O = 1,
       M = null,
       C = 3,
       T = !1,
       P = !1,
       R = !1
     function N(e) {
-      for (var t = E(O); null !== t; ) {
-        if (null === t.callback) S(O)
+      for (var t = E(x); null !== t; ) {
+        if (null === t.callback) S(x)
         else {
           if (!(t.startTime <= e)) break
-          S(O), (t.sortIndex = t.expirationTime), k(x, t)
+          S(x), (t.sortIndex = t.expirationTime), k(_, t)
         }
-        t = E(O)
+        t = E(x)
       }
     }
     function z(e) {
       if (((R = !1), N(e), !P))
-        if (null !== E(x)) (P = !0), t(L)
+        if (null !== E(_)) (P = !0), t(L)
         else {
-          var r = E(O)
+          var r = E(x)
           null !== r && n(z, r.startTime - e)
         }
     }
@@ -3176,7 +3176,7 @@
       var a = C
       try {
         for (
-          N(o), M = E(x);
+          N(o), M = E(_);
           null !== M &&
           (!(M.expirationTime > o) || (t && !e.unstable_shouldYield()));
 
@@ -3186,14 +3186,14 @@
             ;(M.callback = null), (C = M.priorityLevel)
             var l = i(M.expirationTime <= o)
             ;(o = e.unstable_now()),
-              'function' == typeof l ? (M.callback = l) : M === E(x) && S(x),
+              'function' == typeof l ? (M.callback = l) : M === E(_) && S(_),
               N(o)
-          } else S(x)
-          M = E(x)
+          } else S(_)
+          M = E(_)
         }
         if (null !== M) var u = !0
         else {
-          var s = E(O)
+          var s = E(x)
           null !== s && n(z, s.startTime - o), (u = !1)
         }
         return u
@@ -3218,7 +3218,7 @@
         return C
       }),
       (e.unstable_getFirstCallbackNode = function () {
-        return E(x)
+        return E(_)
       }),
       (e.unstable_next = function (e) {
         switch (C) {
@@ -3284,7 +3284,7 @@
         }
         return (
           (o = {
-            id: _++,
+            id: O++,
             callback: a,
             priorityLevel: o,
             startTime: i,
@@ -3293,9 +3293,9 @@
           }),
           i > l
             ? ((o.sortIndex = i),
-              k(O, o),
-              null === E(x) && o === E(O) && (R ? r() : (R = !0), n(z, i - l)))
-            : ((o.sortIndex = u), k(x, o), P || T || ((P = !0), t(L))),
+              k(x, o),
+              null === E(_) && o === E(x) && (R ? r() : (R = !0), n(z, i - l)))
+            : ((o.sortIndex = u), k(_, o), P || T || ((P = !0), t(L))),
           o
         )
       }),
@@ -3323,7 +3323,7 @@
    * This source code is licensed under the MIT license found in the
    * LICENSE file in the root directory of this source tree.
    */
-  var $o = x,
+  var $o = _,
     Yo = R,
     qo = Ho
   function Ko(e) {
@@ -3538,28 +3538,28 @@
     Ea = 60121,
     Sa = 60128,
     Da = 60129,
-    xa = 60130,
-    Oa = 60131
+    _a = 60130,
+    xa = 60131
   if ('function' == typeof Symbol && Symbol.for) {
-    var _a = Symbol.for
-    ;(ca = _a('react.element')),
-      (fa = _a('react.portal')),
-      (da = _a('react.fragment')),
-      (pa = _a('react.strict_mode')),
-      (va = _a('react.profiler')),
-      (ha = _a('react.provider')),
-      (ma = _a('react.context')),
-      (ga = _a('react.forward_ref')),
-      (ya = _a('react.suspense')),
-      (ba = _a('react.suspense_list')),
-      (wa = _a('react.memo')),
-      (ka = _a('react.lazy')),
-      (Ea = _a('react.block')),
-      _a('react.scope'),
-      (Sa = _a('react.opaque.id')),
-      (Da = _a('react.debug_trace_mode')),
-      (xa = _a('react.offscreen')),
-      (Oa = _a('react.legacy_hidden'))
+    var Oa = Symbol.for
+    ;(ca = Oa('react.element')),
+      (fa = Oa('react.portal')),
+      (da = Oa('react.fragment')),
+      (pa = Oa('react.strict_mode')),
+      (va = Oa('react.profiler')),
+      (ha = Oa('react.provider')),
+      (ma = Oa('react.context')),
+      (ga = Oa('react.forward_ref')),
+      (ya = Oa('react.suspense')),
+      (ba = Oa('react.suspense_list')),
+      (wa = Oa('react.memo')),
+      (ka = Oa('react.lazy')),
+      (Ea = Oa('react.block')),
+      Oa('react.scope'),
+      (Sa = Oa('react.opaque.id')),
+      (Da = Oa('react.debug_trace_mode')),
+      (_a = Oa('react.offscreen')),
+      (xa = Oa('react.legacy_hidden'))
   }
   var Ma,
     Ca = 'function' == typeof Symbol && Symbol.iterator
@@ -4133,9 +4133,9 @@
   }
   function Si() {}
   var Di = ki,
-    xi = !1,
-    Oi = !1
-  function _i() {
+    _i = !1,
+    xi = !1
+  function Oi() {
     ;(null === mi && null === gi) || (Si(), wi())
   }
   function Mi(e, t) {
@@ -4565,7 +4565,7 @@
   }
   ;(0, qo.unstable_now)()
   var Dl = 8
-  function xl(e) {
+  function _l(e) {
     if (0 != (1 & e)) return (Dl = 15), 1
     if (0 != (2 & e)) return (Dl = 14), 2
     if (0 != (4 & e)) return (Dl = 13), 4
@@ -4596,7 +4596,7 @@
       ? ((Dl = 1), 1073741824)
       : ((Dl = 8), e)
   }
-  function Ol(e, t) {
+  function xl(e, t) {
     var n = e.pendingLanes
     if (0 === n) return (Dl = 0)
     var r = 0,
@@ -4608,18 +4608,18 @@
     else if (0 !== (a = 134217727 & n)) {
       var u = a & ~i
       0 !== u
-        ? ((r = xl(u)), (o = Dl))
-        : 0 !== (l &= a) && ((r = xl(l)), (o = Dl))
+        ? ((r = _l(u)), (o = Dl))
+        : 0 !== (l &= a) && ((r = _l(l)), (o = Dl))
     } else
       0 !== (a = n & ~i)
-        ? ((r = xl(a)), (o = Dl))
-        : 0 !== l && ((r = xl(l)), (o = Dl))
+        ? ((r = _l(a)), (o = Dl))
+        : 0 !== l && ((r = _l(l)), (o = Dl))
     if (0 === r) return 0
     if (
       ((r = n & (((0 > (r = 31 - Rl(r)) ? 0 : 1 << r) << 1) - 1)),
       0 !== t && t !== r && 0 == (t & i))
     ) {
-      if ((xl(t), o <= Dl)) return t
+      if ((_l(t), o <= Dl)) return t
       Dl = o
     }
     if (0 !== (t = e.entangledLanes))
@@ -4627,7 +4627,7 @@
         (o = 1 << (n = 31 - Rl(t))), (r |= e[n]), (t &= ~o)
     return r
   }
-  function _l(e) {
+  function Ol(e) {
     return 0 !== (e = -1073741825 & e.pendingLanes)
       ? e
       : 1073741824 & e
@@ -4681,14 +4681,14 @@
     jl = qo.unstable_runWithPriority,
     Al = !0
   function Fl(e, t, n, r) {
-    xi || Si()
+    _i || Si()
     var o = Ul,
-      a = xi
-    xi = !0
+      a = _i
+    _i = !0
     try {
       Ei(o, e, t, n, r)
     } finally {
-      ;(xi = a) || _i()
+      ;(_i = a) || Oi()
     }
   }
   function Il(e, t, n, r) {
@@ -5046,10 +5046,10 @@
     Eu = Ql(ku),
     Su = [9, 13, 27, 32],
     Du = Zo && 'CompositionEvent' in window,
-    xu = null
-  Zo && 'documentMode' in document && (xu = document.documentMode)
-  var Ou = Zo && 'TextEvent' in window && !xu,
-    _u = Zo && (!Du || (xu && 8 < xu && 11 >= xu)),
+    _u = null
+  Zo && 'documentMode' in document && (_u = document.documentMode)
+  var xu = Zo && 'TextEvent' in window && !_u,
+    Ou = Zo && (!Du || (_u && 8 < _u && 11 >= _u)),
     Mu = String.fromCharCode(32),
     Cu = !1
   function Tu(e, t) {
@@ -5128,13 +5128,13 @@
   function Yu(e) {
     if ('value' === e.propertyName && Iu(Au)) {
       var t = []
-      if ((Lu(t, Au, e, vi(e)), (e = Fu), xi)) e(t)
+      if ((Lu(t, Au, e, vi(e)), (e = Fu), _i)) e(t)
       else {
-        xi = !0
+        _i = !0
         try {
           ki(e, t)
         } finally {
-          ;(xi = !1), _i()
+          ;(_i = !1), Oi()
         }
       }
     }
@@ -5458,12 +5458,12 @@
         r = r.return
       }
     !(function (e, t, n) {
-      if (Oi) return e(t, n)
-      Oi = !0
+      if (xi) return e(t, n)
+      xi = !0
       try {
         Di(e, t, n)
       } finally {
-        ;(Oi = !1), _i()
+        ;(xi = !1), Oi()
       }
     })(function () {
       var r = a,
@@ -5614,19 +5614,19 @@
             u && s)
           )
             e: {
-              for (d = s, v = 0, p = c = u; p; p = xs(p)) v++
-              for (p = 0, h = d; h; h = xs(h)) p++
-              for (; 0 < v - p; ) (c = xs(c)), v--
-              for (; 0 < p - v; ) (d = xs(d)), p--
+              for (d = s, v = 0, p = c = u; p; p = _s(p)) v++
+              for (p = 0, h = d; h; h = _s(h)) p++
+              for (; 0 < v - p; ) (c = _s(c)), v--
+              for (; 0 < p - v; ) (d = _s(d)), p--
               for (; v--; ) {
                 if (c === d || (null !== d && c === d.alternate)) break e
-                ;(c = xs(c)), (d = xs(d))
+                ;(c = _s(c)), (d = _s(d))
               }
               c = null
             }
           else c = null
-          null !== u && Os(i, l, u, c, !1),
-            null !== s && null !== f && Os(i, f, s, c, !0)
+          null !== u && xs(i, l, u, c, !1),
+            null !== s && null !== f && xs(i, f, s, c, !0)
         }
         if (
           'select' ===
@@ -5700,7 +5700,7 @@
             ? Tu(e, n) && (b = 'onCompositionEnd')
             : 'keydown' === e && 229 === n.keyCode && (b = 'onCompositionStart')
         b &&
-          (_u &&
+          (Ou &&
             'ko' !== n.locale &&
             (Ru || 'onCompositionStart' !== b
               ? 'onCompositionEnd' === b && Ru && (y = $l())
@@ -5710,7 +5710,7 @@
             ((b = new cu(b, e, null, n, o)),
             i.push({ event: b, listeners: g }),
             y ? (b.data = y) : null !== (y = Pu(n)) && (b.data = y))),
-          (y = Ou
+          (y = xu
             ? (function (e, t) {
                 switch (e) {
                   case 'compositionend':
@@ -5742,7 +5742,7 @@
                     }
                     return null
                   case 'compositionend':
-                    return _u && 'ko' !== t.locale ? null : t.data
+                    return Ou && 'ko' !== t.locale ? null : t.data
                 }
               })(e, n)) &&
             0 < (r = Ds(r, 'onBeforeInput')).length &&
@@ -5769,14 +5769,14 @@
     }
     return r
   }
-  function xs(e) {
+  function _s(e) {
     if (null === e) return null
     do {
       e = e.return
     } while (e && 5 !== e.tag)
     return e || null
   }
-  function Os(e, t, n, r, o) {
+  function xs(e, t, n, r, o) {
     for (var a = t._reactName, i = []; null !== n && n !== r; ) {
       var l = n,
         u = l.alternate,
@@ -5792,7 +5792,7 @@
     }
     0 !== i.length && e.push({ event: t, listeners: i })
   }
-  function _s() {}
+  function Os() {}
   var Ms = null,
     Cs = null
   function Ts(e, t) {
@@ -5974,9 +5974,9 @@
     Ec = qo.unstable_LowPriority,
     Sc = qo.unstable_IdlePriority,
     Dc = {},
-    xc = void 0 !== mc ? mc : function () {},
+    _c = void 0 !== mc ? mc : function () {},
+    xc = null,
     Oc = null,
-    _c = null,
     Mc = !1,
     Cc = gc(),
     Tc =
@@ -6024,18 +6024,18 @@
     return (e = Rc(e)), pc(e, t, n)
   }
   function Lc() {
-    if (null !== _c) {
-      var e = _c
-      ;(_c = null), vc(e)
+    if (null !== Oc) {
+      var e = Oc
+      ;(Oc = null), vc(e)
     }
     jc()
   }
   function jc() {
-    if (!Mc && null !== Oc) {
+    if (!Mc && null !== xc) {
       Mc = !0
       var e = 0
       try {
-        var t = Oc
+        var t = xc
         Nc(99, function () {
           for (; e < t.length; e++) {
             var n = t[e]
@@ -6044,9 +6044,9 @@
             } while (null !== n)
           }
         }),
-          (Oc = null)
+          (xc = null)
       } catch (t) {
-        throw (null !== Oc && (Oc = Oc.slice(e + 1)), pc(bc, Lc), t)
+        throw (null !== xc && (xc = xc.slice(e + 1)), pc(bc, Lc), t)
       } finally {
         Mc = !1
       }
@@ -6753,8 +6753,8 @@
   function Df(e) {
     yf.current === e && (Gs(gf), Gs(yf))
   }
-  var xf = Xs(0)
-  function Of(e) {
+  var _f = Xs(0)
+  function xf(e) {
     for (var t = e; null !== t; ) {
       if (13 === t.tag) {
         var n = t.memoizedState
@@ -6778,7 +6778,7 @@
     }
     return null
   }
-  var _f = null,
+  var Of = null,
     Mf = null,
     Cf = !1
   function Tf(e, t) {
@@ -6819,11 +6819,11 @@
         var n = t
         if (!Pf(e, t)) {
           if (!(t = Ls(n.nextSibling)) || !Pf(e, t))
-            return (e.flags = (-1025 & e.flags) | 2), (Cf = !1), void (_f = e)
-          Tf(_f, n)
+            return (e.flags = (-1025 & e.flags) | 2), (Cf = !1), void (Of = e)
+          Tf(Of, n)
         }
-        ;(_f = e), (Mf = Ls(t.firstChild))
-      } else (e.flags = (-1025 & e.flags) | 2), (Cf = !1), (_f = e)
+        ;(Of = e), (Mf = Ls(t.firstChild))
+      } else (e.flags = (-1025 & e.flags) | 2), (Cf = !1), (Of = e)
     }
   }
   function Nf(e) {
@@ -6833,10 +6833,10 @@
 
     )
       e = e.return
-    _f = e
+    Of = e
   }
   function zf(e) {
-    if (e !== _f) return !1
+    if (e !== Of) return !1
     if (!Cf) return Nf(e), (Cf = !0), !1
     var t = e.type
     if (
@@ -6863,11 +6863,11 @@
         }
         Mf = null
       }
-    } else Mf = _f ? Ls(e.stateNode.nextSibling) : null
+    } else Mf = Of ? Ls(e.stateNode.nextSibling) : null
     return !0
   }
   function Lf() {
-    ;(Mf = _f = null), (Cf = !1)
+    ;(Mf = Of = null), (Cf = !1)
   }
   var jf = []
   function Af() {
@@ -7484,24 +7484,24 @@
     },
     Sd = sa.ReactCurrentOwner,
     Dd = !1
-  function xd(e, t, n, r) {
+  function _d(e, t, n, r) {
     t.child = null === e ? hf(t, null, n, r) : vf(t, e.child, n, r)
   }
-  function Od(e, t, n, r, o) {
+  function xd(e, t, n, r, o) {
     n = n.render
     var a = t.ref
     return (
       Yc(t, o),
       (r = Kf(e, t, n, r, a, o)),
       null === e || Dd
-        ? ((t.flags |= 1), xd(e, t, r, o), t.child)
+        ? ((t.flags |= 1), _d(e, t, r, o), t.child)
         : ((t.updateQueue = e.updateQueue),
           (t.flags &= -517),
           (e.lanes &= ~o),
           Yd(e, t, o))
     )
   }
-  function _d(e, t, n, r, o, a) {
+  function Od(e, t, n, r, o, a) {
     if (null === e) {
       var i = n.type
       return 'function' != typeof i ||
@@ -7554,7 +7554,7 @@
     else
       null !== a ? ((r = a.baseLanes | n), (t.memoizedState = null)) : (r = n),
         sv(t, r)
-    return xd(e, t, o, n), t.child
+    return _d(e, t, o, n), t.child
   }
   function Td(e, t) {
     var n = t.ref
@@ -7568,7 +7568,7 @@
       Yc(t, o),
       (n = Kf(e, t, n, r, a, o)),
       null === e || Dd
-        ? ((t.flags |= 1), xd(e, t, n, o), t.child)
+        ? ((t.flags |= 1), _d(e, t, n, o), t.child)
         : ((t.updateQueue = e.updateQueue),
           (t.flags &= -517),
           (e.lanes &= ~o),
@@ -7697,7 +7697,7 @@
       (t.flags |= 1),
       null !== e && i
         ? ((t.child = vf(t, e.child, null, a)), (t.child = vf(t, null, l, a)))
-        : xd(e, t, l, a),
+        : _d(e, t, l, a),
       (t.memoizedState = r.state),
       o && sc(t, n, !0),
       t.child
@@ -7717,7 +7717,7 @@
   function Id(e, t, n) {
     var r,
       o = t.pendingProps,
-      a = xf.current,
+      a = _f.current,
       i = !1
     return (
       (r = 0 != (64 & t.flags)) ||
@@ -7728,7 +7728,7 @@
           void 0 === o.fallback ||
           !0 === o.unstable_avoidThisFallback ||
           (a |= 1),
-      Js(xf, 1 & a),
+      Js(_f, 1 & a),
       null === e
         ? (void 0 !== o.fallback && Rf(t),
           (e = o.children),
@@ -7847,7 +7847,7 @@
     var r = t.pendingProps,
       o = r.revealOrder,
       a = r.tail
-    if ((xd(e, t, r.children, n), 0 != (2 & (r = xf.current))))
+    if ((_d(e, t, r.children, n), 0 != (2 & (r = _f.current))))
       (r = (1 & r) | 2), (t.flags |= 64)
     else {
       if (null !== e && 0 != (64 & e.flags))
@@ -7867,12 +7867,12 @@
         }
       r &= 1
     }
-    if ((Js(xf, r), 0 == (2 & t.mode))) t.memoizedState = null
+    if ((Js(_f, r), 0 == (2 & t.mode))) t.memoizedState = null
     else
       switch (o) {
         case 'forwards':
           for (n = t.child, o = null; null !== n; )
-            null !== (e = n.alternate) && null === Of(e) && (o = n),
+            null !== (e = n.alternate) && null === xf(e) && (o = n),
               (n = n.sibling)
           null === (n = o)
             ? ((o = t.child), (t.child = null))
@@ -7881,7 +7881,7 @@
           break
         case 'backwards':
           for (n = null, o = t.child, t.child = null; null !== o; ) {
-            if (null !== (e = o.alternate) && null === Of(e)) {
+            if (null !== (e = o.alternate) && null === xf(e)) {
               t.child = o
               break
             }
@@ -8037,7 +8037,7 @@
               case 'option':
                 break
               default:
-                'function' == typeof a.onClick && (r.onclick = _s)
+                'function' == typeof a.onClick && (r.onclick = Os)
             }
             ;(r = e), (t.updateQueue = r), null !== r && (t.flags |= 4)
           } else {
@@ -8144,7 +8144,7 @@
                       Ka(e, !!r.multiple, r.defaultValue, !0)
                 break
               default:
-                'function' == typeof o.onClick && (e.onclick = _s)
+                'function' == typeof o.onClick && (e.onclick = Os)
             }
             Ts(n, r) && (t.flags |= 4)
           }
@@ -8170,7 +8170,7 @@
         return null
       case 13:
         return (
-          Gs(xf),
+          Gs(_f),
           (r = t.memoizedState),
           0 != (64 & t.flags)
             ? ((t.lanes = n), t)
@@ -8184,9 +8184,9 @@
                 0 != (2 & t.mode) &&
                 ((null === e &&
                   !0 !== t.memoizedProps.unstable_avoidThisFallback) ||
-                0 != (1 & xf.current)
-                  ? 0 === xp && (xp = 3)
-                  : ((0 !== xp && 3 !== xp) || (xp = 4),
+                0 != (1 & _f.current)
+                  ? 0 === _p && (_p = 3)
+                  : ((0 !== _p && 3 !== _p) || (_p = 4),
                     null === wp ||
                       (0 == (134217727 & Mp) && 0 == (134217727 & Cp)) ||
                       av(wp, Ep))),
@@ -8198,13 +8198,13 @@
       case 10:
         return Bc(t), null
       case 19:
-        if ((Gs(xf), null === (r = t.memoizedState))) return null
+        if ((Gs(_f), null === (r = t.memoizedState))) return null
         if (((a = 0 != (64 & t.flags)), null === (i = r.rendering)))
           if (a) qd(r, !1)
           else {
-            if (0 !== xp || (null !== e && 0 != (64 & e.flags)))
+            if (0 !== _p || (null !== e && 0 != (64 & e.flags)))
               for (e = t.child; null !== e; ) {
-                if (null !== (i = Of(e))) {
+                if (null !== (i = xf(e))) {
                   for (
                     t.flags |= 64,
                       qd(r, !1),
@@ -8247,7 +8247,7 @@
                                   firstContext: e.firstContext,
                                 })),
                       (n = n.sibling)
-                  return Js(xf, (1 & xf.current) | 2), t.child
+                  return Js(_f, (1 & _f.current) | 2), t.child
                 }
                 e = e.sibling
               }
@@ -8257,7 +8257,7 @@
           }
         else {
           if (!a)
-            if (null !== (e = Of(i))) {
+            if (null !== (e = xf(i))) {
               if (
                 ((t.flags |= 64),
                 (a = !0),
@@ -8290,8 +8290,8 @@
             (r.lastEffect = t.lastEffect),
             (r.renderingStartTime = Tc()),
             (n.sibling = null),
-            (t = xf.current),
-            Js(xf, a ? (1 & t) | 2 : 1 & t),
+            (t = _f.current),
+            Js(_f, a ? (1 & t) | 2 : 1 & t),
             n)
           : null
       case 23:
@@ -8321,11 +8321,11 @@
         return Df(e), null
       case 13:
         return (
-          Gs(xf),
+          Gs(_f),
           4096 & (t = e.flags) ? ((e.flags = (-4097 & t) | 64), e) : null
         )
       case 19:
-        return Gs(xf), null
+        return Gs(_f), null
       case 4:
         return Ef(), null
       case 10:
@@ -8398,7 +8398,7 @@
           default:
             'function' != typeof o.onClick &&
               'function' == typeof r.onClick &&
-              (e.onclick = _s)
+              (e.onclick = Os)
         }
         for (s in (di(n, r), (n = null), o))
           if (!r.hasOwnProperty(s) && o.hasOwnProperty(s) && null != o[s])
@@ -8499,7 +8499,7 @@
         try {
           t(null)
         } catch (t) {
-          _v(e, t)
+          Ov(e, t)
         }
       else t.current = null
   }
@@ -8670,7 +8670,7 @@
                 try {
                   o()
                 } catch (e) {
-                  _v(r, e)
+                  Ov(r, e)
                 }
               }
             n = n.next
@@ -8686,7 +8686,7 @@
               (e.state = t.memoizedState),
               e.componentWillUnmount()
           } catch (e) {
-            _v(t, e)
+            Ov(t, e)
           }
         break
       case 5:
@@ -8770,7 +8770,7 @@
               : (t = n).appendChild(e),
             null != (n = n._reactRootContainer) ||
               null !== t.onclick ||
-              (t.onclick = _s))
+              (t.onclick = Os))
     else if (4 !== r && null !== (e = e.child))
       for (cp(e, t, n), e = e.sibling; null !== e; )
         cp(e, t, n), (e = e.sibling)
@@ -8959,9 +8959,9 @@
     Ep = 0,
     Sp = 0,
     Dp = Xs(0),
-    xp = 0,
-    Op = null,
     _p = 0,
+    xp = null,
+    Op = 0,
     Mp = 0,
     Cp = 0,
     Tp = 0,
@@ -8995,7 +8995,7 @@
   function ev(e) {
     if (0 == (2 & (e = e.mode))) return 1
     if (0 == (4 & e)) return 99 === Pc() ? 1 : 2
-    if ((0 === Qp && (Qp = _p), 0 !== Ac.transition)) {
+    if ((0 === Qp && (Qp = Op), 0 !== Ac.transition)) {
       0 !== Xp && (Xp = null !== Pp ? Pp.pendingLanes : 0), (e = Qp)
       var t = 4186112 & ~Xp
       return (
@@ -9030,7 +9030,7 @@
   function tv(e, t, n) {
     if (50 < Yp) throw ((Yp = 0), (qp = null), Error(Ko(185)))
     if (null === (e = nv(e, t))) return null
-    Pl(e, t, n), e === wp && ((Cp |= t), 4 === xp && av(e, Ep))
+    Pl(e, t, n), e === wp && ((Cp |= t), 4 === _p && av(e, Ep))
     var r = Pc()
     1 === t
       ? 0 != (8 & bp) && 0 == (48 & bp)
@@ -9067,14 +9067,14 @@
         s = a[l]
       if (-1 === s) {
         if (0 == (u & r) || 0 != (u & o)) {
-          ;(s = t), xl(u)
+          ;(s = t), _l(u)
           var c = Dl
           a[l] = 10 <= c ? s + 250 : 6 <= c ? s + 5e3 : -1
         }
       } else s <= t && (e.expiredLanes |= u)
       i &= ~u
     }
-    if (((r = Ol(e, e === wp ? Ep : 0)), (t = Dl), 0 === r))
+    if (((r = xl(e, e === wp ? Ep : 0)), (t = Dl), 0 === r))
       null !== n &&
         (n !== Dc && vc(n), (e.callbackNode = null), (e.callbackPriority = 0))
     else {
@@ -9084,7 +9084,7 @@
       }
       15 === t
         ? ((n = iv.bind(null, e)),
-          null === Oc ? ((Oc = [n]), (_c = pc(bc, jc))) : Oc.push(n),
+          null === xc ? ((xc = [n]), (Oc = pc(bc, jc))) : xc.push(n),
           (n = Dc))
         : 14 === t
         ? (n = zc(99, iv.bind(null, e)))
@@ -9124,7 +9124,7 @@
     if (((Kp = -1), (Xp = Qp = 0), 0 != (48 & bp))) throw Error(Ko(327))
     var t = e.callbackNode
     if (Ev() && e.callbackNode !== t) return null
-    var n = Ol(e, e === wp ? Ep : 0)
+    var n = xl(e, e === wp ? Ep : 0)
     if (0 === n) return null
     var r = n,
       o = bp
@@ -9141,8 +9141,8 @@
       (Vc(),
       (gp.current = a),
       (bp = o),
-      null !== kp ? (r = 0) : ((wp = null), (Ep = 0), (r = xp)),
-      0 != (_p & Cp))
+      null !== kp ? (r = 0) : ((wp = null), (Ep = 0), (r = _p)),
+      0 != (Op & Cp))
     )
       fv(e, 0)
     else if (0 !== r) {
@@ -9150,10 +9150,10 @@
         (2 === r &&
           ((bp |= 64),
           e.hydrate && ((e.hydrate = !1), zs(e.containerInfo)),
-          0 !== (n = _l(e)) && (r = vv(e, n))),
+          0 !== (n = Ol(e)) && (r = vv(e, n))),
         1 === r)
       )
-        throw ((t = Op), fv(e, 0), av(e, n), rv(e, Tc()), t)
+        throw ((t = xp), fv(e, 0), av(e, n), rv(e, Tc()), t)
       switch (
         ((e.finishedWork = e.current.alternate), (e.finishedLanes = n), r)
       ) {
@@ -9166,7 +9166,7 @@
           break
         case 3:
           if ((av(e, n), (62914560 & n) === n && 10 < (r = Rp + 500 - Tc()))) {
-            if (0 !== Ol(e, 0)) break
+            if (0 !== xl(e, 0)) break
             if (((o = e.suspendedLanes) & n) !== n) {
               Zp(), (e.pingedLanes |= e.suspendedLanes & o)
               break
@@ -9231,17 +9231,17 @@
     if ((Ev(), e === wp && 0 != (e.expiredLanes & Ep))) {
       var t = Ep,
         n = vv(e, t)
-      0 != (_p & Cp) && (n = vv(e, (t = Ol(e, t))))
-    } else n = vv(e, (t = Ol(e, 0)))
+      0 != (Op & Cp) && (n = vv(e, (t = xl(e, t))))
+    } else n = vv(e, (t = xl(e, 0)))
     if (
       (0 !== e.tag &&
         2 === n &&
         ((bp |= 64),
         e.hydrate && ((e.hydrate = !1), zs(e.containerInfo)),
-        0 !== (t = _l(e)) && (n = vv(e, t))),
+        0 !== (t = Ol(e)) && (n = vv(e, t))),
       1 === n)
     )
-      throw ((n = Op), fv(e, 0), av(e, t), rv(e, Tc()), n)
+      throw ((n = xp), fv(e, 0), av(e, t), rv(e, Tc()), n)
     return (
       (e.finishedWork = e.current.alternate),
       (e.finishedLanes = t),
@@ -9269,7 +9269,7 @@
     }
   }
   function sv(e, t) {
-    Js(Dp, Sp), (Sp |= t), (_p |= t)
+    Js(Dp, Sp), (Sp |= t), (Op |= t)
   }
   function cv() {
     ;(Sp = Dp.current), Gs(Dp)
@@ -9295,7 +9295,7 @@
             break
           case 13:
           case 19:
-            Gs(xf)
+            Gs(_f)
             break
           case 10:
             Bc(r)
@@ -9308,9 +9308,9 @@
       }
     ;(wp = e),
       (kp = Nv(e.current, null)),
-      (Ep = Sp = _p = t),
-      (xp = 0),
-      (Op = null),
+      (Ep = Sp = Op = t),
+      (_p = 0),
+      (xp = null),
       (Tp = Cp = Mp = 0)
   }
   function dv(e, t) {
@@ -9331,7 +9331,7 @@
           (yp.current = null),
           null === n || null === n.return)
         ) {
-          ;(xp = 1), (Op = t), (kp = null)
+          ;(_p = 1), (xp = t), (kp = null)
           break
         }
         e: {
@@ -9354,7 +9354,7 @@
                   (l.lanes = c.lanes))
                 : ((l.updateQueue = null), (l.memoizedState = null))
             }
-            var f = 0 != (1 & xf.current),
+            var f = 0 != (1 & _f.current),
               d = i
             do {
               var p
@@ -9414,7 +9414,7 @@
                 ' suspended while rendering, but no fallback UI was specified.\n\nAdd a <Suspense fallback=...> component higher in the tree to provide a loading indicator or placeholder to display.'
             )
           }
-          5 !== xp && (xp = 2), (u = Xd(u, l)), (d = i)
+          5 !== _p && (_p = 2), (u = Xd(u, l)), (d = i)
           do {
             switch (d.tag) {
               case 3:
@@ -9469,7 +9469,7 @@
         dv(e, t)
       }
     if ((Vc(), (bp = n), (gp.current = r), null !== kp)) throw Error(Ko(261))
-    return (wp = null), (Ep = 0), xp
+    return (wp = null), (Ep = 0), _p
   }
   function hv() {
     for (; null !== kp; ) gv(kp)
@@ -9517,7 +9517,7 @@
       if (null !== (t = t.sibling)) return void (kp = t)
       kp = t = e
     } while (null !== t)
-    0 === xp && (xp = 5)
+    0 === _p && (_p = 5)
   }
   function bv(e) {
     var t = Pc()
@@ -9621,7 +9621,7 @@
           kv()
         } catch (e) {
           if (null === jp) throw Error(Ko(330))
-          _v(jp, e), (jp = jp.nextEffect)
+          Ov(jp, e), (jp = jp.nextEffect)
         }
       } while (null !== jp)
       ;(Gp = null), (jp = r)
@@ -9662,7 +9662,7 @@
           }
         } catch (e) {
           if (null === jp) throw Error(Ko(330))
-          _v(jp, e), (jp = jp.nextEffect)
+          Ov(jp, e), (jp = jp.nextEffect)
         }
       } while (null !== jp)
       if (
@@ -9733,10 +9733,10 @@
           }
         } catch (e) {
           if (null === jp) throw Error(Ko(330))
-          _v(jp, e), (jp = jp.nextEffect)
+          Ov(jp, e), (jp = jp.nextEffect)
         }
       } while (null !== jp)
-      ;(jp = null), xc(), (bp = o)
+      ;(jp = null), _c(), (bp = o)
     } else e.current = n
     if (Up) (Up = !1), (Wp = e), (Hp = t)
     else
@@ -9779,7 +9779,7 @@
   function Ev() {
     if (90 !== Hp) {
       var e = 97 < Hp ? 97 : Hp
-      return (Hp = 90), Nc(e, xv)
+      return (Hp = 90), Nc(e, _v)
     }
     return !1
   }
@@ -9799,7 +9799,7 @@
           return Ev(), null
         }))
   }
-  function xv() {
+  function _v() {
     if (null === Wp) return !1
     var e = Wp
     if (((Wp = null), 0 != (48 & bp))) throw Error(Ko(331))
@@ -9816,7 +9816,7 @@
           i()
         } catch (e) {
           if (null === a) throw Error(Ko(330))
-          _v(a, e)
+          Ov(a, e)
         }
     }
     for (n = Vp, Vp = [], r = 0; r < n.length; r += 2) {
@@ -9826,7 +9826,7 @@
         o.destroy = l()
       } catch (e) {
         if (null === a) throw Error(Ko(330))
-        _v(a, e)
+        Ov(a, e)
       }
     }
     for (l = e.current.firstEffect; null !== l; )
@@ -9836,17 +9836,17 @@
         (l = e)
     return (bp = t), Lc(), !0
   }
-  function Ov(e, t, n) {
+  function xv(e, t, n) {
     Jc(e, (t = Zd(0, (t = Xd(n, t)), 1))),
       (t = Zp()),
       null !== (e = nv(e, 1)) && (Pl(e, 1, t), rv(e, t))
   }
-  function _v(e, t) {
-    if (3 === e.tag) Ov(e, e, t)
+  function Ov(e, t) {
+    if (3 === e.tag) xv(e, e, t)
     else
       for (var n = e.return; null !== n; ) {
         if (3 === n.tag) {
-          Ov(n, e, t)
+          xv(n, e, t)
           break
         }
         if (1 === n.tag) {
@@ -9879,7 +9879,7 @@
       (e.pingedLanes |= e.suspendedLanes & n),
       wp === e &&
         (Ep & n) === n &&
-        (4 === xp || (3 === xp && (62914560 & Ep) === Ep && 500 > Tc() - Rp)
+        (4 === _p || (3 === _p && (62914560 & Ep) === Ep && 500 > Tc() - Rp)
           ? fv(e, 0)
           : (Tp |= n)),
       rv(e, t)
@@ -9892,7 +9892,7 @@
           ? (t = 1)
           : 0 == (4 & t)
           ? (t = 99 === Pc() ? 1 : 2)
-          : (0 === Qp && (Qp = _p),
+          : (0 === Qp && (Qp = Op),
             0 === (t = Cl(62914560 & ~Qp)) && (t = 4194304))),
       (n = Zp()),
       null !== (e = nv(e, t)) && (Pl(e, t, n), rv(e, n))
@@ -9987,10 +9987,10 @@
           )
         case ba:
           return ((e = Pv(19, n, t, o)).elementType = ba), (e.lanes = a), e
-        case xa:
+        case _a:
           return jv(n, o, a, t)
-        case Oa:
-          return ((e = Pv(24, n, t, o)).elementType = Oa), (e.lanes = a), e
+        case xa:
+          return ((e = Pv(24, n, t, o)).elementType = xa), (e.lanes = a), e
         default:
           if ('object' == typeof e && null !== e)
             switch (e.$$typeof) {
@@ -10023,7 +10023,7 @@
     return ((e = Pv(7, e, r, t)).lanes = n), e
   }
   function jv(e, t, n, r) {
-    return ((e = Pv(23, e, r, t)).elementType = xa), (e.lanes = n), e
+    return ((e = Pv(23, e, r, t)).elementType = _a), (e.lanes = n), e
   }
   function Av(e, t, n) {
     return ((e = Pv(6, e, null, t)).lanes = n), e
@@ -10245,9 +10245,9 @@
               if (null !== t.memoizedState)
                 return 0 != (n & t.child.childLanes)
                   ? Id(e, t, n)
-                  : (Js(xf, 1 & xf.current),
+                  : (Js(_f, 1 & _f.current),
                     null !== (t = Yd(e, t, n)) ? t.sibling : null)
-              Js(xf, 1 & xf.current)
+              Js(_f, 1 & _f.current)
               break
             case 19:
               if (((r = 0 != (n & t.childLanes)), 0 != (64 & e.flags))) {
@@ -10259,7 +10259,7 @@
                   ((o.rendering = null),
                   (o.tail = null),
                   (o.lastEffect = null)),
-                Js(xf, xf.current),
+                Js(_f, _f.current),
                 r)
               )
                 break
@@ -10308,7 +10308,7 @@
             (o._reactInternals = t),
             sf(t, r, e, n),
             (t = Nd(null, t, r, !0, a, n))
-        } else (t.tag = 0), xd(null, t, o, n), (t = t.child)
+        } else (t.tag = 0), _d(null, t, o, n), (t = t.child)
         return t
       case 16:
         o = t.elementType
@@ -10338,10 +10338,10 @@
               t = Rd(null, t, o, e, n)
               break e
             case 11:
-              t = Od(null, t, o, e, n)
+              t = xd(null, t, o, e, n)
               break e
             case 14:
-              t = _d(null, t, o, Fc(o.type, e), r, n)
+              t = Od(null, t, o, Fc(o.type, e), r, n)
               break e
           }
           throw Error(Ko(306, o, ''))
@@ -10374,7 +10374,7 @@
           if (
             ((a = (o = t.stateNode).hydrate) &&
               ((Mf = Ls(t.stateNode.containerInfo.firstChild)),
-              (_f = t),
+              (Of = t),
               (a = Cf = !0)),
             a)
           ) {
@@ -10384,7 +10384,7 @@
                   jf.push(a)
             for (n = hf(t, null, r, n), t.child = n; n; )
               (n.flags = (-3 & n.flags) | 1024), (n = n.sibling)
-          } else xd(e, t, r, n), Lf()
+          } else _d(e, t, r, n), Lf()
           t = t.child
         }
         return t
@@ -10398,7 +10398,7 @@
           (i = o.children),
           Ps(r, o) ? (i = null) : null !== a && Ps(r, a) && (t.flags |= 16),
           Td(e, t),
-          xd(e, t, i, n),
+          _d(e, t, i, n),
           t.child
         )
       case 6:
@@ -10409,20 +10409,20 @@
         return (
           kf(t, t.stateNode.containerInfo),
           (r = t.pendingProps),
-          null === e ? (t.child = vf(t, null, r, n)) : xd(e, t, r, n),
+          null === e ? (t.child = vf(t, null, r, n)) : _d(e, t, r, n),
           t.child
         )
       case 11:
         return (
           (r = t.type),
           (o = t.pendingProps),
-          Od(e, t, r, (o = t.elementType === r ? o : Fc(r, o)), n)
+          xd(e, t, r, (o = t.elementType === r ? o : Fc(r, o)), n)
         )
       case 7:
-        return xd(e, t, t.pendingProps, n), t.child
+        return _d(e, t, t.pendingProps, n), t.child
       case 8:
       case 12:
-        return xd(e, t, t.pendingProps.children, n), t.child
+        return _d(e, t, t.pendingProps.children, n), t.child
       case 10:
         e: {
           ;(r = t.type._context),
@@ -10477,7 +10477,7 @@
                   }
                 l = i
               }
-          xd(e, t, o.children, n), (t = t.child)
+          _d(e, t, o.children, n), (t = t.child)
         }
         return t
       case 9:
@@ -10487,13 +10487,13 @@
           Yc(t, n),
           (r = r((o = qc(o, a.unstable_observedBits)))),
           (t.flags |= 1),
-          xd(e, t, r, n),
+          _d(e, t, r, n),
           t.child
         )
       case 14:
         return (
           (a = Fc((o = t.type), t.pendingProps)),
-          _d(e, t, o, (a = Fc(o.type, a)), r, n)
+          Od(e, t, o, (a = Fc(o.type, a)), r, n)
         )
       case 15:
         return Md(e, t, t.type, t.pendingProps, r, n)
@@ -10828,7 +10828,7 @@
         (null != (t = e) && t.nodeType && e) || null)
   }
   function uh(e, t) {
-    var n = x.useState(function () {
+    var n = _.useState(function () {
         return lh(e)
       }),
       r = n[0],
@@ -10838,13 +10838,13 @@
       a && o(a)
     }
     return (
-      x.useEffect(
+      _.useEffect(
         function () {
           t && r && t(r)
         },
         [t, r]
       ),
-      x.useEffect(
+      _.useEffect(
         function () {
           var t = lh(e)
           t !== r && o(t)
@@ -10862,7 +10862,7 @@
       : e
   }
   function ch(e, t) {
-    return x.useMemo(
+    return _.useMemo(
       function () {
         return (function (e, t) {
           var n = sh(e),
@@ -10893,7 +10893,7 @@
       g = ch(p, t),
       y = uh(e.container),
       b = uh(e.target),
-      w = x.useState(!e.show),
+      w = _.useState(!e.show),
       k = w[0],
       E = w[1],
       S = (function (e, t, n) {
@@ -10907,17 +10907,17 @@
           f = r.modifiers,
           d = void 0 === f ? Ao : f,
           p = l(r, ['enabled', 'placement', 'strategy', 'modifiers']),
-          v = x.useRef(),
-          h = x.useCallback(function () {
+          v = _.useRef(),
+          h = _.useCallback(function () {
             var e
             null == (e = v.current) || e.update()
           }, []),
-          m = x.useCallback(function () {
+          m = _.useCallback(function () {
             var e
             null == (e = v.current) || e.forceUpdate()
           }, []),
           g = gr(
-            x.useState({
+            _.useState({
               placement: u,
               update: h,
               forceUpdate: m,
@@ -10927,7 +10927,7 @@
           ),
           y = g[0],
           b = g[1],
-          w = x.useMemo(
+          w = _.useMemo(
             function () {
               return {
                 name: 'updateStateModifier',
@@ -10955,7 +10955,7 @@
             [h, m, b]
           )
         return (
-          x.useEffect(
+          _.useEffect(
             function () {
               v.current &&
                 a &&
@@ -10967,7 +10967,7 @@
             },
             [c, u, w, a]
           ),
-          x.useEffect(
+          _.useEffect(
             function () {
               if (a && null != e && null != t)
                 return (
@@ -11011,8 +11011,8 @@
         })
       ),
       D = S.styles,
-      O = S.attributes,
-      _ = l(S, ['styles', 'attributes'])
+      x = S.attributes,
+      O = l(S, ['styles', 'attributes'])
     e.show ? k && E(!1) : e.transition || k || E(!0)
     var M,
       C,
@@ -11037,9 +11037,9 @@
       (R = (P = void 0 === T ? {} : T).disabled),
       (N = P.clickTrigger),
       (z = void 0 === N ? 'click' : N),
-      (L = x.useRef(!1)),
+      (L = _.useRef(!1)),
       (j = C || th),
-      (A = x.useCallback(
+      (A = _.useCallback(
         function (e) {
           var t,
             n,
@@ -11067,7 +11067,7 @@
       (I = hr(function (e) {
         27 === e.keyCode && j(e)
       })),
-      x.useEffect(
+      _.useEffect(
         function () {
           if (!R && null != M) {
             var e = window.event,
@@ -11102,10 +11102,10 @@
     )
       return null
     var W = e.children(
-      ce({}, _, {
+      ce({}, O, {
         show: !!e.show,
-        props: ce({}, O.popper, { style: D.popper, ref: g }),
-        arrowProps: ce({}, O.arrow, { style: D.arrow, ref: m }),
+        props: ce({}, x.popper, { style: D.popper, ref: g }),
+        arrowProps: ce({}, x.arrow, { style: D.arrow, ref: m }),
       })
     )
     if (c) {
@@ -11221,11 +11221,11 @@
               delete E.resizable
               var S = v.title(r),
                 D = v.tooltip(r),
-                x = v.end(r),
-                O = v.start(r),
-                _ = v.allDay(r),
-                M = a || _ || f.diff(O, f.ceil(x, 'day'), 'day') > 1,
-                C = h.eventProp(r, O, x, o),
+                _ = v.end(r),
+                x = v.start(r),
+                O = v.allDay(r),
+                M = a || O || f.diff(x, f.ceil(_, 'day'), 'day') > 1,
+                C = h.eventProp(r, x, _, o),
                 T = se.createElement(
                   'div',
                   { className: 'rbc-event-content', title: D || void 0 },
@@ -11235,7 +11235,7 @@
                         continuesPrior: d,
                         continuesAfter: p,
                         title: S,
-                        isAllDay: _,
+                        isAllDay: O,
                         localizer: f,
                         slotStart: w,
                         slotEnd: k,
@@ -11297,15 +11297,15 @@
         (n == t.length - 1 ? t.pop() : bh.call(t, n, 1), --this.size, !0)
       )
     },
-    xh = function (e) {
+    _h = function (e) {
       var t = this.__data__,
         n = wh(t, e)
       return n < 0 ? void 0 : t[n][1]
     },
-    Oh = function (e) {
+    xh = function (e) {
       return kh(this.__data__, e) > -1
     },
-    _h = function (e, t) {
+    Oh = function (e, t) {
       var n = this.__data__,
         r = Eh(n, e)
       return r < 0 ? (++this.size, n.push([e, t])) : (n[r][1] = t), this
@@ -11320,9 +11320,9 @@
   }
   ;(Mh.prototype.clear = Sh),
     (Mh.prototype.delete = Dh),
-    (Mh.prototype.get = xh),
-    (Mh.prototype.has = Oh),
-    (Mh.prototype.set = _h)
+    (Mh.prototype.get = _h),
+    (Mh.prototype.has = xh),
+    (Mh.prototype.set = Oh)
   var Ch = Mh,
     Th = Ch
   var Ph = function () {
@@ -11455,13 +11455,13 @@
     Em = km
   var Sm = km
   var Dm = km
-  var xm = km
-  var Om = function (e, t) {
-      var n = xm(this, e),
+  var _m = km
+  var xm = function (e, t) {
+      var n = _m(this, e),
         r = n.size
       return n.set(e, t), (this.size += n.size == r ? 0 : 1), this
     },
-    _m = function () {
+    Om = function () {
       ;(this.size = 0),
         (this.__data__ = {
           hash: new gm(),
@@ -11479,7 +11479,7 @@
     Tm = function (e) {
       return Dm(this, e).has(e)
     },
-    Pm = Om
+    Pm = xm
   function Rm(e) {
     var t = -1,
       n = null == e ? 0 : e.length
@@ -11488,7 +11488,7 @@
       this.set(r[0], r[1])
     }
   }
-  ;(Rm.prototype.clear = _m),
+  ;(Rm.prototype.clear = Om),
     (Rm.prototype.delete = Mm),
     (Rm.prototype.get = Cm),
     (Rm.prototype.has = Tm),
@@ -11683,18 +11683,18 @@
     },
     Sg = bn,
     Dg = Object.prototype,
-    xg = Dg.hasOwnProperty,
-    Og = Dg.propertyIsEnumerable,
-    _g = Eg(
+    _g = Dg.hasOwnProperty,
+    xg = Dg.propertyIsEnumerable,
+    Og = Eg(
       (function () {
         return arguments
       })()
     )
       ? Eg
       : function (e) {
-          return Sg(e) && xg.call(e, 'callee') && !Og.call(e, 'callee')
+          return Sg(e) && _g.call(e, 'callee') && !xg.call(e, 'callee')
         },
-    Mg = _g,
+    Mg = Og,
     Cg = {},
     Tg = {
       get exports() {
@@ -11886,20 +11886,20 @@
     Ey = Uh,
     Sy = '[object Map]',
     Dy = '[object Promise]',
-    xy = '[object Set]',
-    Oy = '[object WeakMap]',
-    _y = '[object DataView]',
+    _y = '[object Set]',
+    xy = '[object WeakMap]',
+    Oy = '[object DataView]',
     My = Ey(my),
     Cy = Ey(gy),
     Ty = Ey(yy),
     Py = Ey(by),
     Ry = Ey(wy),
     Ny = ky
-  ;((my && Ny(new my(new ArrayBuffer(1))) != _y) ||
+  ;((my && Ny(new my(new ArrayBuffer(1))) != Oy) ||
     (gy && Ny(new gy()) != Sy) ||
     (yy && Ny(yy.resolve()) != Dy) ||
-    (by && Ny(new by()) != xy) ||
-    (wy && Ny(new wy()) != Oy)) &&
+    (by && Ny(new by()) != _y) ||
+    (wy && Ny(new wy()) != xy)) &&
     (Ny = function (e) {
       var t = ky(e),
         n = '[object Object]' == t ? e.constructor : void 0,
@@ -11907,15 +11907,15 @@
       if (r)
         switch (r) {
           case My:
-            return _y
+            return Oy
           case Cy:
             return Sy
           case Ty:
             return Dy
           case Py:
-            return xy
+            return _y
           case Ry:
-            return Oy
+            return xy
         }
       return t
     })
@@ -12009,7 +12009,7 @@
       k = e.offset
     ;(n = (t = { ref: b, callback: f }).ref),
       (r = t.callback),
-      x.useEffect(
+      _.useEffect(
         function () {
           var e = function (e) {
             n.current && !n.current.contains(e.target) && r()
@@ -12023,7 +12023,7 @@
         },
         [n, r]
       ),
-      x.useLayoutEffect(
+      _.useLayoutEffect(
         function () {
           var e = (function (e) {
               var t = e.target,
@@ -12118,7 +12118,7 @@
       p = e.handleDragStart,
       v = e.onHide,
       h = e.overlayDisplay,
-      m = x.useRef(null)
+      m = _.useRef(null)
     if (!o.position) return null
     var g = r
     isNaN(r) || (g = { x: r, y: r })
@@ -12221,44 +12221,48 @@
     onHide: we.func,
     overlayDisplay: we.func,
   }
-  var lb = function () {
-    var e =
-      arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : document
-    if (e instanceof Document) {
-      var t = document.querySelector(
-        '[data-rh-content-portal-name=create-relay-meeting]'
-      )
-      return null === t ? document : t.shadowRoot
-    }
+  function lb(e) {
+    var t
     return e
+      ? (null == e ? void 0 : e.parentNode) instanceof ShadowRoot &&
+        null != e &&
+        null !== (t = e.parentNode) &&
+        void 0 !== t &&
+        t.host.matches('[data-rh-content-portal]')
+        ? e.parentNode
+        : lb(e.parentElement)
+      : null
   }
-  function ub(e, t) {
-    var n =
-      arguments.length > 2 && void 0 !== arguments[2] ? arguments[2] : document
-    return Fo(lb(n), e, t, { passive: !1 })
+  var ub = function (e) {
+    if (!e || e instanceof Window) return e
+    var t = lb(e)
+    return null === t ? document : t
   }
-  function sb(e, t) {
-    return !!(function (e, t) {
-      var n = t.clientX,
-        r = t.clientY
-      return ib(lb().elementFromPoint(n, r), '.rbc-event', e)
-    })(e, t)
+  function sb(e, t, n) {
+    return Fo(n, e, t, { passive: !1 })
   }
   function cb(e, t) {
     return !!(function (e, t) {
       var n = t.clientX,
         r = t.clientY
-      return ib(lb().elementFromPoint(n, r), '.rbc-show-more', e)
+      return ib(ub(e).elementFromPoint(n, r), '.rbc-event', e)
     })(e, t)
   }
-  function fb(e) {
+  function fb(e, t) {
+    return !!(function (e, t) {
+      var n = t.clientX,
+        r = t.clientY
+      return ib(ub(e).elementFromPoint(n, r), '.rbc-show-more', e)
+    })(e, t)
+  }
+  function db(e) {
     var t = e
     return (
       e.touches && e.touches.length && (t = e.touches[0]),
       { clientX: t.clientX, clientY: t.clientY, pageX: t.pageX, pageY: t.pageY }
     )
   }
-  var db = (function () {
+  var pb = (function () {
     function e(t) {
       var n =
           arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : {},
@@ -12275,6 +12279,7 @@
         (this.longPressThreshold = i),
         (this.validContainers = u),
         (this._listeners = Object.create(null)),
+        (this._targetHost = ub(this.container)),
         (this._handleInitialEvent = this._handleInitialEvent.bind(this)),
         (this._handleMoveEvent = this._handleMoveEvent.bind(this)),
         (this._handleTerminatingEvent =
@@ -12284,20 +12289,30 @@
           this._dropFromOutsideListener.bind(this)),
         (this._dragOverFromOutsideListener =
           this._dragOverFromOutsideListener.bind(this)),
-        (this._removeTouchMoveWindowListener = ub(
+        (this._removeTouchMoveWindowListener = sb(
           'touchmove',
           function () {},
           window
         )),
-        (this._removeKeyDownListener = ub('keydown', this._keyListener)),
-        (this._removeKeyUpListener = ub('keyup', this._keyListener)),
-        (this._removeDropFromOutsideListener = ub(
-          'drop',
-          this._dropFromOutsideListener
+        (this._removeKeyDownListener = sb(
+          'keydown',
+          this._keyListener,
+          this._targetHost
         )),
-        (this._removeDragOverFromOutsideListener = ub(
+        (this._removeKeyUpListener = sb(
+          'keyup',
+          this._keyListener,
+          this._targetHost
+        )),
+        (this._removeDropFromOutsideListener = sb(
+          'drop',
+          this._dropFromOutsideListener,
+          this._targetHost
+        )),
+        (this._removeDragOverFromOutsideListener = sb(
           'dragover',
-          this._dragOverFromOutsideListener
+          this._dragOverFromOutsideListener,
+          this._targetHost
         )),
         this._addInitialEventListener()
     }
@@ -12361,7 +12376,7 @@
           key: 'isSelected',
           value: function (e) {
             var t = this._selectRect
-            return !(!t || !this.selecting) && pb(t, vb(e))
+            return !(!t || !this.selecting) && vb(t, hb(e))
           },
         },
         {
@@ -12383,14 +12398,22 @@
                 ;(r = setTimeout(function () {
                   u(), e(t)
                 }, n.longPressThreshold)),
-                  (o = ub('touchmove', function () {
-                    return u()
-                  })),
-                  (a = ub('touchend', function () {
-                    return u()
-                  }))
+                  (o = sb(
+                    'touchmove',
+                    function () {
+                      return u()
+                    },
+                    n._targetHost
+                  )),
+                  (a = sb(
+                    'touchend',
+                    function () {
+                      return u()
+                    },
+                    n._targetHost
+                  ))
               },
-              l = ub('touchstart', i),
+              l = sb('touchstart', i, this._targetHost),
               u = function () {
                 r && clearTimeout(r),
                   o && o(),
@@ -12411,21 +12434,30 @@
           key: '_addInitialEventListener',
           value: function () {
             var e = this,
-              t = ub('mousedown', function (t) {
-                e._removeInitialEventListener(),
-                  e._handleInitialEvent(t),
-                  (e._removeInitialEventListener = ub(
-                    'mousedown',
-                    e._handleInitialEvent
-                  ))
-              }),
-              n = ub('touchstart', function (t) {
-                e._removeInitialEventListener(),
-                  (e._removeInitialEventListener = e._addLongPressListener(
-                    e._handleInitialEvent,
-                    t
-                  ))
-              })
+              t = sb(
+                'mousedown',
+                function (t) {
+                  e._removeInitialEventListener(),
+                    e._handleInitialEvent(t),
+                    (e._removeInitialEventListener = sb(
+                      'mousedown',
+                      e._handleInitialEvent,
+                      e._targetHost
+                    ))
+                },
+                this._targetHost
+              ),
+              n = sb(
+                'touchstart',
+                function (t) {
+                  e._removeInitialEventListener(),
+                    (e._removeInitialEventListener = e._addLongPressListener(
+                      e._handleInitialEvent,
+                      t
+                    ))
+                },
+                this._targetHost
+              )
             this._removeInitialEventListener = function () {
               t(), n()
             }
@@ -12434,7 +12466,7 @@
         {
           key: '_dropFromOutsideListener',
           value: function (e) {
-            var t = fb(e),
+            var t = db(e),
               n = t.pageX,
               r = t.pageY,
               o = t.clientX,
@@ -12451,7 +12483,7 @@
         {
           key: '_dragOverFromOutsideListener',
           value: function (e) {
-            var t = fb(e),
+            var t = db(e),
               n = t.pageX,
               r = t.pageY,
               o = t.clientX,
@@ -12470,7 +12502,7 @@
           value: function (e) {
             if (!this.isDetached) {
               var t,
-                r = fb(e),
+                r = db(e),
                 o = r.clientX,
                 a = r.clientY,
                 i = r.pageX,
@@ -12480,7 +12512,7 @@
                 3 !== e.which &&
                 2 !== e.button &&
                 (function (e, t, n) {
-                  return !e || Kn(e, lb().elementFromPoint(t, n))
+                  return !e || Kn(e, ub(e).elementFromPoint(t, n))
                 })(u, o, a)
               ) {
                 if (!this.globalMouse && u && !Kn(u, e.target)) {
@@ -12498,9 +12530,9 @@
                     d = s.bottom,
                     p = s.right
                   if (
-                    !pb(
+                    !vb(
                       {
-                        top: (t = vb(u)).top - c,
+                        top: (t = hb(u)).top - c,
                         left: t.left - f,
                         bottom: t.bottom + d,
                         right: t.right + p,
@@ -12525,28 +12557,33 @@
                 )
                   switch (e.type) {
                     case 'mousedown':
-                      ;(this._removeEndListener = ub(
+                      ;(this._removeEndListener = sb(
                         'mouseup',
-                        this._handleTerminatingEvent
+                        this._handleTerminatingEvent,
+                        this._targetHost
                       )),
-                        (this._onEscListener = ub(
+                        (this._onEscListener = sb(
                           'keydown',
-                          this._handleTerminatingEvent
+                          this._handleTerminatingEvent,
+                          this._targetHost
                         )),
-                        (this._removeMoveListener = ub(
+                        (this._removeMoveListener = sb(
                           'mousemove',
-                          this._handleMoveEvent
+                          this._handleMoveEvent,
+                          this._targetHost
                         ))
                       break
                     case 'touchstart':
                       this._handleMoveEvent(e),
-                        (this._removeEndListener = ub(
+                        (this._removeEndListener = sb(
                           'touchend',
-                          this._handleTerminatingEvent
+                          this._handleTerminatingEvent,
+                          this._targetHost
                         )),
-                        (this._removeMoveListener = ub(
+                        (this._removeMoveListener = sb(
                           'touchmove',
-                          this._handleMoveEvent
+                          this._handleMoveEvent,
+                          this._targetHost
                         ))
                   }
               }
@@ -12569,7 +12606,7 @@
         {
           key: '_handleTerminatingEvent',
           value: function (e) {
-            var t = fb(e),
+            var t = db(e),
               n = t.pageX,
               r = t.pageY
             if (
@@ -12598,7 +12635,7 @@
         {
           key: '_handleClickEvent',
           value: function (e) {
-            var t = fb(e),
+            var t = db(e),
               n = t.pageX,
               r = t.pageY,
               o = t.clientX,
@@ -12624,7 +12661,7 @@
               var t = this._initialEventData,
                 n = t.x,
                 r = t.y,
-                o = fb(e),
+                o = db(e),
                 a = o.pageX,
                 i = o.pageY,
                 l = Math.abs(n - a),
@@ -12667,16 +12704,16 @@
       e
     )
   })()
-  function pb(e, t) {
+  function vb(e, t) {
     var n = arguments.length > 2 && void 0 !== arguments[2] ? arguments[2] : 0,
-      r = vb(e),
+      r = hb(e),
       o = r.top,
       a = r.left,
       i = r.right,
       l = void 0 === i ? a : i,
       u = r.bottom,
       s = void 0 === u ? o : u,
-      c = vb(t),
+      c = hb(t),
       f = c.top,
       d = c.left,
       p = c.right,
@@ -12685,11 +12722,11 @@
       m = void 0 === h ? f : h
     return !(s - n < f || o + n > m || l - n < d || a + n > v)
   }
-  function vb(e) {
+  function hb(e) {
     if (!e.getBoundingClientRect) return e
     var t = e.getBoundingClientRect(),
-      n = t.left + hb('left'),
-      r = t.top + hb('top')
+      n = t.left + mb('left'),
+      r = t.top + mb('top')
     return {
       top: r,
       left: n,
@@ -12697,14 +12734,14 @@
       bottom: (e.offsetHeight || 0) + r,
     }
   }
-  function hb(e) {
+  function mb(e) {
     return 'left' === e
       ? window.pageXOffset || document.body.scrollLeft || 0
       : 'top' === e
       ? window.pageYOffset || document.body.scrollTop || 0
       : void 0
   }
-  var mb = (function (e) {
+  var gb = (function (e) {
       p(n, e)
       var t = g(n)
       function n(e, r) {
@@ -12712,7 +12749,7 @@
         return (
           s(this, n),
           ((o = t.call(this, e, r)).state = { selecting: !1 }),
-          (o.containerRef = x.createRef()),
+          (o.containerRef = _.createRef()),
           o
         )
       }
@@ -12785,12 +12822,12 @@
             value: function () {
               var e = this,
                 t = this.containerRef.current,
-                n = (this._selector = new db(this.props.container, {
+                n = (this._selector = new pb(this.props.container, {
                   longPressThreshold: this.props.longPressThreshold,
                 })),
                 r = function (n, r) {
-                  if (!sb(t, n) && !cb(t, n)) {
-                    var o = vb(t),
+                  if (!cb(t, n) && !fb(t, n)) {
+                    var o = hb(t),
                       a = e.props,
                       i = a.range,
                       l = a.rtl
@@ -12825,11 +12862,11 @@
                   u = -1
                 if (
                   (e.state.selecting ||
-                    (_e(e.props.onSelectStart, [r]),
+                    (Oe(e.props.onSelectStart, [r]),
                     (e._initial = { x: r.x, y: r.y })),
                   n.isSelected(t))
                 ) {
-                  var s = vb(t),
+                  var s = hb(t),
                     c = (function (e, t, n, r, o) {
                       var a = -1,
                         i = -1,
@@ -12866,7 +12903,7 @@
               }),
                 n.on('beforeSelect', function (t) {
                   if ('ignoreEvents' === e.props.selectable)
-                    return !sb(e.containerRef.current, t)
+                    return !cb(e.containerRef.current, t)
                 }),
                 n.on('click', function (e) {
                   return r(e, 'click')
@@ -12880,7 +12917,7 @@
                   ),
                     (e._initial = {}),
                     e.setState({ selecting: !1 }),
-                    _e(e.props.onSelectEnd, [e.state])
+                    Oe(e.props.onSelectEnd, [e.state])
                 })
             },
           },
@@ -12916,7 +12953,7 @@
         n
       )
     })(se.Component),
-    gb =
+    yb =
       (we.object.isRequired,
       we.object,
       we.bool,
@@ -12928,7 +12965,7 @@
       we.func,
       we.func,
       { segments: [], selected: {} }),
-    yb = function (e, t) {
+    bb = function (e, t) {
       var n = e.selected
       e.isAllDay
       var r = e.accessors,
@@ -12959,7 +12996,7 @@
         resizable: f,
       })
     },
-    bb = function (e, t, n) {
+    wb = function (e, t, n) {
       var r =
           arguments.length > 3 && void 0 !== arguments[3] ? arguments[3] : ' ',
         o = (Math.abs(t) / e) * 100 + '%'
@@ -12973,7 +13010,7 @@
         r
       )
     },
-    wb = (function (e) {
+    kb = (function (e) {
       p(n, e)
       var t = g(n)
       function n() {
@@ -13000,10 +13037,10 @@
                     s = n.span,
                     c = '_lvl_' + o,
                     f = l - a,
-                    d = yb(e.props, i)
+                    d = bb(e.props, i)
                   return (
-                    f && t.push(bb(r, f, ''.concat(c, '_gap'))),
-                    t.push(bb(r, s, c, d)),
+                    f && t.push(wb(r, f, ''.concat(c, '_gap'))),
+                    t.push(wb(r, s, c, d)),
                     (a = u + 1),
                     t
                   )
@@ -13015,26 +13052,26 @@
         n
       )
     })(se.Component)
-  wb.defaultProps = i({}, gb)
-  var kb = function (e, t, n, r) {
+  kb.defaultProps = i({}, yb)
+  var Eb = function (e, t, n, r) {
       for (var o = e.length, a = n + (r ? 1 : -1); r ? a-- : ++a < o; )
         if (t(e[a], a, e)) return a
       return -1
     },
-    Eb = Bm,
-    Sb = Qy
-  var Db = en
+    Sb = Bm,
+    Db = Qy
+  var _b = en
   var xb = function (e) {
-      return e == e && !Db(e)
+      return e == e && !_b(e)
     },
     Ob = xb,
-    _b = uy
-  var Mb = function (e, t) {
+    Mb = uy
+  var Cb = function (e, t) {
       return function (n) {
         return null != n && n[e] === t && (void 0 !== t || e in Object(n))
       }
     },
-    Cb = function (e, t, n, r) {
+    Tb = function (e, t, n, r) {
       var o = n.length,
         a = o,
         i = !r
@@ -13050,36 +13087,36 @@
         if (i && l[2]) {
           if (void 0 === s && !(u in e)) return !1
         } else {
-          var f = new Eb()
+          var f = new Sb()
           if (r) var d = r(s, c, u, e, t, f)
-          if (!(void 0 === d ? Sb(c, s, 3, r, f) : d)) return !1
+          if (!(void 0 === d ? Db(c, s, 3, r, f) : d)) return !1
         }
       }
       return !0
     },
-    Tb = function (e) {
-      for (var t = _b(e), n = t.length; n--; ) {
+    Pb = function (e) {
+      for (var t = Mb(e), n = t.length; n--; ) {
         var r = t[n],
           o = e[r]
         t[n] = [r, o, Ob(o)]
       }
       return t
     },
-    Pb = Mb
-  var Rb = function (e) {
-      var t = Tb(e)
+    Rb = Cb
+  var Nb = function (e) {
+      var t = Pb(e)
       return 1 == t.length && t[0][2]
-        ? Pb(t[0][0], t[0][1])
+        ? Rb(t[0][0], t[0][1])
         : function (n) {
-            return n === e || Cb(n, e, t)
+            return n === e || Tb(n, e, t)
           }
     },
-    Nb = sg,
-    zb = En,
-    Lb = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
-    jb = /^\w*$/
-  var Ab = function (e, t) {
-      if (Nb(e)) return !1
+    zb = sg,
+    Lb = En,
+    jb = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
+    Ab = /^\w*$/
+  var Fb = function (e, t) {
+      if (zb(e)) return !1
       var n = typeof e
       return (
         !(
@@ -13087,15 +13124,15 @@
           'symbol' != n &&
           'boolean' != n &&
           null != e &&
-          !zb(e)
+          !Lb(e)
         ) ||
-        jb.test(e) ||
-        !Lb.test(e) ||
+        Ab.test(e) ||
+        !jb.test(e) ||
         (null != t && e in Object(t))
       )
     },
-    Fb = Nm
-  function Ib(e, t) {
+    Ib = Nm
+  function Ub(e, t) {
     if ('function' != typeof e || (null != t && 'function' != typeof t))
       throw new TypeError('Expected a function')
     var n = function () {
@@ -13106,15 +13143,15 @@
       var i = e.apply(this, r)
       return (n.cache = a.set(o, i) || a), i
     }
-    return (n.cache = new (Ib.Cache || Fb)()), n
+    return (n.cache = new (Ub.Cache || Ib)()), n
   }
-  Ib.Cache = Fb
-  var Ub = Ib
-  var Wb =
+  Ub.Cache = Ib
+  var Wb = Ub
+  var Hb =
       /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g,
-    Hb = /\\(\\)?/g,
-    Vb = (function (e) {
-      var t = Ub(e, function (e) {
+    Vb = /\\(\\)?/g,
+    Bb = (function (e) {
+      var t = Wb(e, function (e) {
           return 500 === n.size && n.clear(), e
         }),
         n = t.cache
@@ -13123,146 +13160,146 @@
       var t = []
       return (
         46 === e.charCodeAt(0) && t.push(''),
-        e.replace(Wb, function (e, n, r, o) {
-          t.push(r ? o.replace(Hb, '$1') : n || e)
+        e.replace(Hb, function (e, n, r, o) {
+          t.push(r ? o.replace(Vb, '$1') : n || e)
         }),
         t
       )
     })
-  var Bb = function (e, t) {
+  var $b = function (e, t) {
       for (var n = -1, r = null == e ? 0 : e.length, o = Array(r); ++n < r; )
         o[n] = t(e[n], n, e)
       return o
     },
-    $b = Bb,
-    Yb = sg,
-    qb = En,
-    Kb = Ht ? Ht.prototype : void 0,
-    Qb = Kb ? Kb.toString : void 0
-  var Xb = function e(t) {
+    Yb = $b,
+    qb = sg,
+    Kb = En,
+    Qb = Ht ? Ht.prototype : void 0,
+    Xb = Qb ? Qb.toString : void 0
+  var Gb = function e(t) {
       if ('string' == typeof t) return t
-      if (Yb(t)) return $b(t, e) + ''
-      if (qb(t)) return Qb ? Qb.call(t) : ''
+      if (qb(t)) return Yb(t, e) + ''
+      if (Kb(t)) return Xb ? Xb.call(t) : ''
       var n = t + ''
       return '0' == n && 1 / t == -Infinity ? '-0' : n
     },
-    Gb = Xb
-  var Jb = sg,
-    Zb = Ab,
-    ew = Vb,
-    tw = function (e) {
-      return null == e ? '' : Gb(e)
+    Jb = Gb
+  var Zb = sg,
+    ew = Fb,
+    tw = Bb,
+    nw = function (e) {
+      return null == e ? '' : Jb(e)
     }
-  var nw = function (e, t) {
-      return Jb(e) ? e : Zb(e, t) ? [e] : ew(tw(e))
+  var rw = function (e, t) {
+      return Zb(e) ? e : ew(e, t) ? [e] : tw(nw(e))
     },
-    rw = En
-  var ow = function (e) {
-      if ('string' == typeof e || rw(e)) return e
+    ow = En
+  var aw = function (e) {
+      if ('string' == typeof e || ow(e)) return e
       var t = e + ''
       return '0' == t && 1 / e == -Infinity ? '-0' : t
     },
-    aw = nw,
-    iw = ow
-  var lw = function (e, t) {
-      for (var n = 0, r = (t = aw(t, e)).length; null != e && n < r; )
-        e = e[iw(t[n++])]
+    iw = rw,
+    lw = aw
+  var uw = function (e, t) {
+      for (var n = 0, r = (t = iw(t, e)).length; null != e && n < r; )
+        e = e[lw(t[n++])]
       return n && n == r ? e : void 0
     },
-    uw = lw
-  var sw = nw,
-    cw = Mg,
-    fw = sg,
-    dw = cn,
-    pw = on,
-    vw = ow
-  var hw = function (e, t) {
+    sw = uw
+  var cw = rw,
+    fw = Mg,
+    dw = sg,
+    pw = cn,
+    vw = on,
+    hw = aw
+  var mw = function (e, t) {
       return null != e && t in Object(e)
     },
-    mw = function (e, t, n) {
-      for (var r = -1, o = (t = sw(t, e)).length, a = !1; ++r < o; ) {
-        var i = vw(t[r])
+    gw = function (e, t, n) {
+      for (var r = -1, o = (t = cw(t, e)).length, a = !1; ++r < o; ) {
+        var i = hw(t[r])
         if (!(a = null != e && n(e, i))) break
         e = e[i]
       }
       return a || ++r != o
         ? a
         : !!(o = null == e ? 0 : e.length) &&
-            pw(o) &&
-            dw(i, o) &&
-            (fw(e) || cw(e))
+            vw(o) &&
+            pw(i, o) &&
+            (dw(e) || fw(e))
     }
-  var gw = Qy,
-    yw = function (e, t, n) {
-      var r = null == e ? void 0 : uw(e, t)
+  var yw = Qy,
+    bw = function (e, t, n) {
+      var r = null == e ? void 0 : sw(e, t)
       return void 0 === r ? n : r
     },
-    bw = function (e, t) {
-      return null != e && mw(e, t, hw)
+    ww = function (e, t) {
+      return null != e && gw(e, t, mw)
     },
-    ww = Ab,
-    kw = xb,
-    Ew = Mb,
-    Sw = ow
-  var Dw = function (e) {
+    kw = Fb,
+    Ew = xb,
+    Sw = Cb,
+    Dw = aw
+  var _w = function (e) {
     return e
   }
-  var xw = lw
+  var xw = uw
   var Ow = function (e) {
       return function (t) {
         return null == t ? void 0 : t[e]
       }
     },
-    _w = function (e) {
+    Mw = function (e) {
       return function (t) {
         return xw(t, e)
       }
     },
-    Mw = Ab,
-    Cw = ow
-  var Tw = Rb,
-    Pw = function (e, t) {
-      return ww(e) && kw(t)
-        ? Ew(Sw(e), t)
+    Cw = Fb,
+    Tw = aw
+  var Pw = Nb,
+    Rw = function (e, t) {
+      return kw(e) && Ew(t)
+        ? Sw(Dw(e), t)
         : function (n) {
-            var r = yw(n, e)
-            return void 0 === r && r === t ? bw(n, e) : gw(t, r, 3)
+            var r = bw(n, e)
+            return void 0 === r && r === t ? ww(n, e) : yw(t, r, 3)
           }
     },
-    Rw = Dw,
-    Nw = sg,
-    zw = function (e) {
-      return Mw(e) ? Ow(Cw(e)) : _w(e)
+    Nw = _w,
+    zw = sg,
+    Lw = function (e) {
+      return Cw(e) ? Ow(Tw(e)) : Mw(e)
     }
-  var Lw = function (e) {
+  var jw = function (e) {
       return 'function' == typeof e
         ? e
         : null == e
-        ? Rw
+        ? Nw
         : 'object' == typeof e
-        ? Nw(e)
-          ? Pw(e[0], e[1])
-          : Tw(e)
-        : zw(e)
+        ? zw(e)
+          ? Rw(e[0], e[1])
+          : Pw(e)
+        : Lw(e)
     },
-    jw = kb,
-    Aw = Lw,
-    Fw = zn,
-    Iw = Math.max
-  var Uw = function (e, t, n) {
+    Aw = Eb,
+    Fw = jw,
+    Iw = zn,
+    Uw = Math.max
+  var Ww = function (e, t, n) {
     var r = null == e ? 0 : e.length
     if (!r) return -1
-    var o = null == n ? 0 : Fw(n)
-    return o < 0 && (o = Iw(r + o, 0)), jw(e, Aw(t), o)
+    var o = null == n ? 0 : Iw(n)
+    return o < 0 && (o = Uw(r + o, 0)), Aw(e, Fw(t), o)
   }
-  function Ww(e) {
+  function Hw(e) {
     var t = e.dateRange,
       n = e.unit,
       r = void 0 === n ? 'day' : n,
       o = e.localizer
     return { first: t[0], last: o.add(t[t.length - 1], 1, r) }
   }
-  function Hw(e) {
+  function Vw(e) {
     var t,
       n,
       r,
@@ -13271,7 +13308,7 @@
       a = [],
       i = []
     for (t = 0; t < e.length; t++) {
-      for (r = e[t], n = 0; n < a.length && Bw(r, a[n]); n++);
+      for (r = e[t], n = 0; n < a.length && $w(r, a[n]); n++);
       n >= o ? i.push(r) : (a[n] || (a[n] = [])).push(r)
     }
     for (t = 0; t < a.length; t++)
@@ -13280,52 +13317,52 @@
       })
     return { levels: a, extra: i }
   }
-  function Vw(e, t, n, r, o) {
+  function Bw(e, t, n, r, o) {
     var a = { start: r.start(e), end: r.end(e) },
       i = { start: t, end: n }
     return o.inEventRange({ event: a, range: i })
   }
-  function Bw(e, t) {
+  function $w(e, t) {
     return t.some(function (t) {
       return t.left <= e.right && t.right >= e.left
     })
   }
-  function $w(e, t, n, r) {
+  function Yw(e, t, n, r) {
     var o = { start: n.start(e), end: n.end(e), allDay: n.allDay(e) },
       a = { start: n.start(t), end: n.end(t), allDay: n.allDay(t) }
     return r.sortEvents({ evtA: o, evtB: a })
   }
-  var Yw = Math.ceil,
-    qw = Math.max
-  var Kw = function (e, t, n, r) {
-      for (var o = -1, a = qw(Yw((t - e) / (n || 1)), 0), i = Array(a); a--; )
+  var qw = Math.ceil,
+    Kw = Math.max
+  var Qw = function (e, t, n, r) {
+      for (var o = -1, a = Kw(qw((t - e) / (n || 1)), 0), i = Array(a); a--; )
         (i[r ? a : ++o] = e), (e += n)
       return i
     },
-    Qw = Kw,
-    Xw = hn,
-    Gw = Rn
-  var Jw = function (e) {
+    Xw = Qw,
+    Gw = hn,
+    Jw = Rn
+  var Zw = function (e) {
       return function (t, n, r) {
         return (
-          r && 'number' != typeof r && Xw(t, n, r) && (n = r = void 0),
-          (t = Gw(t)),
-          void 0 === n ? ((n = t), (t = 0)) : (n = Gw(n)),
-          (r = void 0 === r ? (t < n ? 1 : -1) : Gw(r)),
-          Qw(t, n, r, e)
+          r && 'number' != typeof r && Gw(t, n, r) && (n = r = void 0),
+          (t = Jw(t)),
+          void 0 === n ? ((n = t), (t = 0)) : (n = Jw(n)),
+          (r = void 0 === r ? (t < n ? 1 : -1) : Jw(r)),
+          Xw(t, n, r, e)
         )
       }
     },
-    Zw = Jw(),
-    ek = function (e, t) {
+    ek = Zw(),
+    tk = function (e, t) {
       return e.left <= t && e.right >= t
     },
-    tk = function (e, t) {
+    nk = function (e, t) {
       return e.filter(function (e) {
-        return ek(e, t)
+        return tk(e, t)
       }).length
     },
-    nk = (function (e) {
+    rk = (function (e) {
       p(n, e)
       var t = g(n)
       function n() {
@@ -13340,7 +13377,7 @@
                 var e = this.props,
                   t = e.segments,
                   n = e.slotMetrics.slots,
-                  r = Hw(t).levels[0],
+                  r = Vw(t).levels[0],
                   o = 1,
                   a = 1,
                   i = [];
@@ -13350,7 +13387,7 @@
                 var l = '_lvl_' + o,
                   u =
                     r.filter(function (e) {
-                      return ek(e, o)
+                      return tk(e, o)
                     })[0] || {},
                   s = u.event,
                   c = u.left,
@@ -13359,13 +13396,13 @@
                 if (s) {
                   var p = Math.max(0, c - a)
                   if (this.canRenderSlotEvent(c, d)) {
-                    var v = yb(this.props, s)
-                    p && i.push(bb(n, p, l + '_gap')),
-                      i.push(bb(n, d, l, v)),
+                    var v = bb(this.props, s)
+                    p && i.push(wb(n, p, l + '_gap')),
+                      i.push(wb(n, d, l, v)),
                       (a = o = f + 1)
                   } else
-                    p && i.push(bb(n, p, l + '_gap')),
-                      i.push(bb(n, 1, l, this.renderShowMore(t, o))),
+                    p && i.push(wb(n, p, l + '_gap')),
+                      i.push(wb(n, 1, l, this.renderShowMore(t, o))),
                       (a = o += 1)
                 } else o++
               }
@@ -13376,8 +13413,8 @@
             key: 'canRenderSlotEvent',
             value: function (e, t) {
               var n = this.props.segments
-              return Zw(e, e + t).every(function (e) {
-                return 1 === tk(n, e)
+              return ek(e, e + t).every(function (e) {
+                return 1 === nk(n, e)
               })
             },
           },
@@ -13386,7 +13423,7 @@
             value: function (e, t) {
               var n = this,
                 r = this.props.localizer,
-                o = tk(e, t)
+                o = nk(e, t)
               return (
                 !!o &&
                 se.createElement(
@@ -13416,8 +13453,8 @@
         n
       )
     })(se.Component)
-  nk.defaultProps = i({}, gb)
-  var rk = function (e) {
+  rk.defaultProps = i({}, yb)
+  var ok = function (e) {
       var t = e.children
       return se.createElement(
         'div',
@@ -13425,20 +13462,20 @@
         t
       )
     },
-    ok =
+    ak =
       Number.isNaN ||
       function (e) {
         return 'number' == typeof e && e != e
       }
-  function ak(e, t) {
+  function ik(e, t) {
     if (e.length !== t.length) return !1
     for (var n = 0; n < e.length; n++)
-      if (((r = e[n]), (o = t[n]), !(r === o || (ok(r) && ok(o))))) return !1
+      if (((r = e[n]), (o = t[n]), !(r === o || (ak(r) && ak(o))))) return !1
     var r, o
     return !0
   }
-  function ik(e, t) {
-    void 0 === t && (t = ak)
+  function lk(e, t) {
+    void 0 === t && (t = ik)
     var n = null
     function r() {
       for (var r = [], o = 0; o < arguments.length; o++) r[o] = arguments[o]
@@ -13453,11 +13490,11 @@
       r
     )
   }
-  var lk = function (e, t) {
+  var uk = function (e, t) {
     return e[0].range === t[0].range && e[0].events === t[0].events
   }
-  function uk() {
-    return ik(function (e) {
+  function sk() {
+    return lk(function (e) {
       for (
         var t = e.range,
           n = e.events,
@@ -13465,18 +13502,18 @@
           o = e.minRows,
           a = e.accessors,
           l = e.localizer,
-          u = Ww({ dateRange: t, localizer: l }),
+          u = Hw({ dateRange: t, localizer: l }),
           s = u.first,
           c = u.last,
           f = n.map(function (e) {
             return (function (e, t, n, r) {
-              var o = Ww({ dateRange: t, localizer: r }),
+              var o = Hw({ dateRange: t, localizer: r }),
                 a = o.first,
                 i = o.last,
                 l = r.diff(a, i, 'day'),
                 u = r.max(r.startOf(n.start(e), 'day'), a),
                 s = r.min(r.ceil(n.end(e), 'day'), i),
-                c = Uw(t, function (e) {
+                c = Ww(t, function (e) {
                   return r.isSameDate(e, u)
                 }),
                 f = r.diff(u, s, 'day')
@@ -13491,7 +13528,7 @@
               )
             })(e, t, a, l)
           }),
-          d = Hw(f, Math.max(r - 1, 1)),
+          d = Vw(f, Math.max(r - 1, 1)),
           p = d.levels,
           v = d.extra,
           h = v.length > 0 ? o - 1 : o;
@@ -13507,7 +13544,7 @@
         range: t,
         slots: t.length,
         clone: function (t) {
-          return uk()(i(i({}, e), t))
+          return sk()(i(i({}, e), t))
         },
         getDateForSlot: function (e) {
           return t[e]
@@ -13537,9 +13574,9 @@
           return l.continuesAfter(t, n, c)
         },
       }
-    }, lk)
+    }, uk)
   }
-  var sk = (function (e) {
+  var ck = (function (e) {
     p(r, e)
     var n = g(r)
     function r() {
@@ -13623,10 +13660,10 @@
             )
           )
         }),
-        (e.containerRef = x.createRef()),
-        (e.headingRowRef = x.createRef()),
-        (e.eventRowRef = x.createRef()),
-        (e.slotMetrics = uk()),
+        (e.containerRef = _.createRef()),
+        (e.headingRowRef = _.createRef()),
+        (e.eventRowRef = _.createRef()),
+        (e.slotMetrics = sk()),
         e
       )
     }
@@ -13673,10 +13710,10 @@
               S = e.resizable,
               D = e.showAllEvents
             if (u) return this.renderDummy()
-            var x = this.slotMetrics(this.props),
-              O = x.levels,
-              _ = x.extra,
-              M = D ? rk : t,
+            var _ = this.slotMetrics(this.props),
+              x = _.levels,
+              O = _.extra,
+              M = D ? ok : t,
               C = f.weekWrapper,
               T = {
                 selected: i,
@@ -13688,13 +13725,13 @@
                 onDoubleClick: y,
                 onKeyPress: b,
                 resourceId: w,
-                slotMetrics: x,
+                slotMetrics: _,
                 resizable: S,
               }
             return se.createElement(
               'div',
               { className: a, role: 'rowgroup', ref: this.containerRef },
-              se.createElement(mb, {
+              se.createElement(gb, {
                 localizer: h,
                 date: n,
                 getNow: d,
@@ -13731,17 +13768,17 @@
                   se.createElement(
                     C,
                     Object.assign({ isAllDay: E }, T, { rtl: this.props.rtl }),
-                    O.map(function (e, t) {
+                    x.map(function (e, t) {
                       return se.createElement(
-                        wb,
+                        kb,
                         Object.assign({ key: t, segments: e }, T)
                       )
                     }),
-                    !!_.length &&
+                    !!O.length &&
                       se.createElement(
-                        nk,
+                        rk,
                         Object.assign(
-                          { segments: _, onShowMore: this.handleShowMore },
+                          { segments: O, onShowMore: this.handleShowMore },
                           T
                         )
                       )
@@ -13755,8 +13792,8 @@
       r
     )
   })(se.Component)
-  sk.defaultProps = { minRows: 0, maxRows: 1 / 0 }
-  var ck = function (e) {
+  ck.defaultProps = { minRows: 0, maxRows: 1 / 0 }
+  var fk = function (e) {
       var t = e.label
       return se.createElement(
         'span',
@@ -13764,7 +13801,7 @@
         t
       )
     },
-    fk = function (e) {
+    dk = function (e) {
       var t = e.label,
         n = e.drilldownView,
         r = e.onDrillDown
@@ -13780,15 +13817,14 @@
             t
           )
         : se.createElement('span', null, t)
-    }
-  fk.propTypes = {}
-  var dk = ['date', 'className'],
-    pk = function (e, t, n, r, o) {
+    },
+    pk = ['date', 'className'],
+    vk = function (e, t, n, r, o) {
       return e.filter(function (e) {
-        return Vw(e, t, n, r, o)
+        return Bw(e, t, n, r, o)
       })
     },
-    vk = (function (e) {
+    hk = (function (e) {
       p(n, e)
       var t = g(n)
       function n() {
@@ -13816,12 +13852,12 @@
               h = e.state,
               m = h.needLimitMeasure,
               g = h.rowLimit,
-              y = pk(Lt(o), t[0], t[t.length - 1], d, c)
+              y = vk(Lt(o), t[0], t[t.length - 1], d, c)
             return (
               y.sort(function (e, t) {
-                return $w(e, t, d, c)
+                return Yw(e, t, d, c)
               }),
-              se.createElement(sk, {
+              se.createElement(ck, {
                 key: n,
                 ref: 0 === n ? e.slotRowRef : void 0,
                 container: e.getContainer,
@@ -13854,7 +13890,7 @@
           (e.readerDateHeading = function (t) {
             var n = t.date,
               r = t.className,
-              o = u(t, dk),
+              o = u(t, pk),
               a = e.props,
               i = a.date,
               l = a.getDrilldownView,
@@ -13863,7 +13899,7 @@
               f = s.isSameDate(n, i),
               d = l(n),
               p = s.format(n, 'dateFormat'),
-              v = e.props.components.dateHeader || fk
+              v = e.props.components.dateHeader || dk
             return se.createElement(
               'div',
               Object.assign({}, o, {
@@ -13891,25 +13927,25 @@
           (e.handleHeadingClick = function (t, n, r) {
             r.preventDefault(),
               e.clearSelection(),
-              _e(e.props.onDrillDown, [t, n])
+              Oe(e.props.onDrillDown, [t, n])
           }),
           (e.handleSelectEvent = function () {
             e.clearSelection()
             for (var t = arguments.length, n = new Array(t), r = 0; r < t; r++)
               n[r] = arguments[r]
-            _e(e.props.onSelectEvent, n)
+            Oe(e.props.onSelectEvent, n)
           }),
           (e.handleDoubleClickEvent = function () {
             e.clearSelection()
             for (var t = arguments.length, n = new Array(t), r = 0; r < t; r++)
               n[r] = arguments[r]
-            _e(e.props.onDoubleClickEvent, n)
+            Oe(e.props.onDoubleClickEvent, n)
           }),
           (e.handleKeyPressEvent = function () {
             e.clearSelection()
             for (var t = arguments.length, n = new Array(t), r = 0; r < t; r++)
               n[r] = arguments[r]
-            _e(e.props.onKeyPressEvent, n)
+            Oe(e.props.onKeyPressEvent, n)
           }),
           (e.handleShowMore = function (t, n, r, o, a) {
             var i = e.props,
@@ -13923,15 +13959,15 @@
               e.setState({
                 overlay: { date: n, events: t, position: d, target: a },
               })
-            } else f && _e(u, [n, c(n) || xe.DAY])
-            _e(s, [t, n, o])
+            } else f && Oe(u, [n, c(n) || _e.DAY])
+            Oe(s, [t, n, o])
           }),
           (e.overlayDisplay = function () {
             e.setState({ overlay: null })
           }),
           (e.state = { rowLimit: 5, needLimitMeasure: !0, date: null }),
-          (e.containerRef = x.createRef()),
-          (e.slotRowRef = x.createRef()),
+          (e.containerRef = _.createRef()),
+          (e.slotRowRef = _.createRef()),
           (e._bgRows = []),
           (e._pendingSelection = []),
           e
@@ -14009,7 +14045,7 @@
                   r = t.components,
                   o = e[0],
                   a = e[e.length - 1],
-                  i = r.header || ck
+                  i = r.header || fk
                 return n.range(o, a, 'day').map(function (e, t) {
                   return se.createElement(
                     'div',
@@ -14086,7 +14122,7 @@
                 var n = new Date(t[0]),
                   r = new Date(t[t.length - 1])
                 r.setDate(t[t.length - 1].getDate() + 1),
-                  _e(this.props.onSelectSlot, {
+                  Oe(this.props.onSelectSlot, {
                     slots: t,
                     start: n,
                     end: r,
@@ -14119,11 +14155,11 @@
         n
       )
     })(se.Component)
-  ;(vk.range = function (e, t) {
+  ;(hk.range = function (e, t) {
     var n = t.localizer
     return { start: n.firstVisibleDay(e, n), end: n.lastVisibleDay(e, n) }
   }),
-    (vk.navigate = function (e, t, n) {
+    (hk.navigate = function (e, t, n) {
       var r = n.localizer
       switch (t) {
         case De.PREVIOUS:
@@ -14134,10 +14170,10 @@
           return e
       }
     }),
-    (vk.title = function (e, t) {
+    (hk.title = function (e, t) {
       return t.localizer.format(e, 'monthHeaderFormat')
     })
-  var hk = function (e) {
+  var mk = function (e) {
     var t = e.min,
       n = e.max,
       r = e.step,
@@ -14149,14 +14185,14 @@
       ''.concat(r, '-').concat(o)
     )
   }
-  function mk(e) {
+  function gk(e) {
     for (
       var t = e.min,
         n = e.max,
         r = e.step,
         o = e.timeslots,
         a = e.localizer,
-        i = hk({ start: t, end: n, step: r, timeslots: o, localizer: a }),
+        i = mk({ start: t, end: n, step: r, timeslots: o, localizer: a }),
         l = 1 + a.getTotalMin(t, n),
         u = a.getMinutesFromMidnight(t),
         s = Math.ceil((l - 1) / (r * o)),
@@ -14184,7 +14220,7 @@
       {
         groups: f,
         update: function (e) {
-          return hk(e) !== i ? mk(e) : this
+          return mk(e) !== i ? gk(e) : this
         },
         dateIsInGroup: function (e, t) {
           var r = f[t + 1]
@@ -14245,27 +14281,158 @@
       }
     )
   }
-  var gk = Mg,
-    yk = sg,
-    bk = Ht ? Ht.isConcatSpreadable : void 0
-  var wk = ug,
-    kk = function (e) {
-      return yk(e) || gk(e) || !!(bk && e && e[bk])
+  function yk(e) {
+    return 'string' == typeof e ? e : e + '%'
+  }
+  function bk(e) {
+    var t = e.style,
+      n = e.className,
+      r = e.event,
+      a = e.accessors,
+      l = e.rtl,
+      u = e.selected,
+      s = e.label,
+      c = e.continuesPrior,
+      f = e.continuesAfter,
+      d = e.getters,
+      p = e.onClick,
+      v = e.onDoubleClick,
+      h = e.isBackgroundEvent,
+      m = e.onKeyPress,
+      g = e.components,
+      y = g.event,
+      b = g.eventWrapper,
+      w = a.title(r),
+      k = a.tooltip(r),
+      E = a.end(r),
+      S = a.start(r),
+      D = d.eventProp(r, S, E, u),
+      _ = t.height,
+      x = t.top,
+      O = t.width,
+      M = t.xOffset,
+      C = [
+        se.createElement('div', { key: '1', className: 'rbc-event-label' }, s),
+        se.createElement(
+          'div',
+          { key: '2', className: 'rbc-event-content' },
+          y ? se.createElement(y, { event: r, title: w }) : w
+        ),
+      ],
+      T = i(
+        i({}, D.style),
+        {},
+        h
+          ? o(
+              {
+                top: yk(x),
+                height: yk(_),
+                width: 'calc('.concat(O, ' + 10px)'),
+              },
+              l ? 'right' : 'left',
+              yk(Math.max(0, M))
+            )
+          : o(
+              { top: yk(x), width: yk(O), height: yk(_) },
+              l ? 'right' : 'left',
+              yk(M)
+            )
+      )
+    return se.createElement(
+      b,
+      Object.assign({ type: 'time' }, e),
+      se.createElement(
+        'div',
+        {
+          role: 'button',
+          tabIndex: 0,
+          onClick: p,
+          onDoubleClick: v,
+          style: T,
+          onKeyPress: m,
+          title: k ? ('string' == typeof s ? s + ': ' : '') + k : void 0,
+          className: be(
+            h ? 'rbc-background-event' : 'rbc-event',
+            n,
+            D.className,
+            {
+              'rbc-selected': u,
+              'rbc-event-continues-earlier': c,
+              'rbc-event-continues-later': f,
+            }
+          ),
+        },
+        C
+      )
+    )
+  }
+  var wk = (function (e) {
+      p(r, e)
+      var n = g(r)
+      function r() {
+        return s(this, r), n.apply(this, arguments)
+      }
+      return (
+        f(r, [
+          {
+            key: 'render',
+            value: function () {
+              var e = this.props,
+                n = e.renderSlot,
+                r = e.resource,
+                o = e.group,
+                a = e.getters,
+                i = e.components,
+                l = void 0 === i ? {} : i,
+                u = l.timeSlotWrapper,
+                s = void 0 === u ? t : u,
+                c = l.slotChildrenWrapper,
+                f = a ? a.slotGroupProp(o) : {}
+              return se.createElement(
+                'div',
+                Object.assign({ className: 'rbc-timeslot-group' }, f),
+                o.map(function (e, t) {
+                  var o = a ? a.slotProp(e, r) : {}
+                  return se.createElement(
+                    s,
+                    { key: t, value: e, resource: r },
+                    se.createElement(
+                      'div',
+                      Object.assign({}, o, {
+                        className: be('rbc-time-slot', o.className),
+                      }),
+                      n ? n(e, t) : null == c ? void 0 : c(o)
+                    )
+                  )
+                })
+              )
+            },
+          },
+        ]),
+        r
+      )
+    })(_.Component),
+    kk = Mg,
+    Ek = sg,
+    Sk = Ht ? Ht.isConcatSpreadable : void 0
+  var Dk = ug,
+    _k = function (e) {
+      return Ek(e) || kk(e) || !!(Sk && e && e[Sk])
     }
-  var Ek = function e(t, n, r, o, a) {
+  var xk = function e(t, n, r, o, a) {
     var i = -1,
       l = t.length
-    for (r || (r = kk), a || (a = []); ++i < l; ) {
+    for (r || (r = _k), a || (a = []); ++i < l; ) {
       var u = t[i]
       n > 0 && r(u)
         ? n > 1
           ? e(u, n - 1, r, o, a)
-          : wk(a, u)
+          : Dk(a, u)
         : o || (a[a.length] = u)
     }
     return a
   }
-  var Sk = (function (e) {
+  var Ok = (function (e) {
       return function (t, n, r) {
         for (var o = -1, a = Object(t), i = r(t), l = i.length; l--; ) {
           var u = i[e ? l : ++o]
@@ -14274,15 +14441,15 @@
         return t
       }
     })(),
-    Dk = uy
-  var xk = function (e, t) {
-      return e && Sk(e, t, Dk)
+    Mk = uy
+  var Ck = function (e, t) {
+      return e && Ok(e, t, Mk)
     },
-    Ok = un
-  var _k = (function (e, t) {
+    Tk = un
+  var Pk = (function (e, t) {
       return function (n, r) {
         if (null == n) return n
-        if (!Ok(n)) return e(n, r)
+        if (!Tk(n)) return e(n, r)
         for (
           var o = n.length, a = t ? o : -1, i = Object(n);
           (t ? a-- : ++a < o) && !1 !== r(i[a], a, i);
@@ -14290,19 +14457,19 @@
         );
         return n
       }
-    })(xk),
-    Mk = un
-  var Ck = En
-  var Tk = function (e, t) {
+    })(Ck),
+    Rk = un
+  var Nk = En
+  var zk = function (e, t) {
     if (e !== t) {
       var n = void 0 !== e,
         r = null === e,
         o = e == e,
-        a = Ck(e),
+        a = Nk(e),
         i = void 0 !== t,
         l = null === t,
         u = t == t,
-        s = Ck(t)
+        s = Nk(t)
       if (
         (!l && !s && !a && e > t) ||
         (a && i && u && !l && !s) ||
@@ -14322,64 +14489,64 @@
     }
     return 0
   }
-  var Pk = Bb,
-    Rk = lw,
-    Nk = Lw,
-    zk = function (e, t) {
+  var Lk = $b,
+    jk = uw,
+    Ak = jw,
+    Fk = function (e, t) {
       var n = -1,
-        r = Mk(e) ? Array(e.length) : []
+        r = Rk(e) ? Array(e.length) : []
       return (
-        _k(e, function (e, o, a) {
+        Pk(e, function (e, o, a) {
           r[++n] = t(e, o, a)
         }),
         r
       )
     },
-    Lk = function (e, t) {
+    Ik = function (e, t) {
       var n = e.length
       for (e.sort(t); n--; ) e[n] = e[n].value
       return e
     },
-    jk = Ag,
-    Ak = function (e, t, n) {
+    Uk = Ag,
+    Wk = function (e, t, n) {
       for (
         var r = -1, o = e.criteria, a = t.criteria, i = o.length, l = n.length;
         ++r < i;
 
       ) {
-        var u = Tk(o[r], a[r])
+        var u = zk(o[r], a[r])
         if (u) return r >= l ? u : u * ('desc' == n[r] ? -1 : 1)
       }
       return e.index - t.index
     },
-    Fk = Dw,
-    Ik = sg
-  var Uk = function (e, t, n) {
+    Hk = _w,
+    Vk = sg
+  var Bk = function (e, t, n) {
     t = t.length
-      ? Pk(t, function (e) {
-          return Ik(e)
+      ? Lk(t, function (e) {
+          return Vk(e)
             ? function (t) {
-                return Rk(t, 1 === e.length ? e[0] : e)
+                return jk(t, 1 === e.length ? e[0] : e)
               }
             : e
         })
-      : [Fk]
+      : [Hk]
     var r = -1
-    t = Pk(t, jk(Nk))
-    var o = zk(e, function (e, n, o) {
+    t = Lk(t, Uk(Ak))
+    var o = Fk(e, function (e, n, o) {
       return {
-        criteria: Pk(t, function (t) {
+        criteria: Lk(t, function (t) {
           return t(e)
         }),
         index: ++r,
         value: e,
       }
     })
-    return Lk(o, function (e, t) {
-      return Ak(e, t, n)
+    return Ik(o, function (e, t) {
+      return Wk(e, t, n)
     })
   }
-  var Wk = function (e, t, n) {
+  var $k = function (e, t, n) {
       switch (n.length) {
         case 0:
           return e.call(t)
@@ -14392,53 +14559,53 @@
       }
       return e.apply(t, n)
     },
-    Hk = Math.max
-  var Vk = function (e, t, n) {
+    Yk = Math.max
+  var qk = function (e, t, n) {
     return (
-      (t = Hk(void 0 === t ? e.length - 1 : t, 0)),
+      (t = Yk(void 0 === t ? e.length - 1 : t, 0)),
       function () {
         for (
-          var r = arguments, o = -1, a = Hk(r.length - t, 0), i = Array(a);
+          var r = arguments, o = -1, a = Yk(r.length - t, 0), i = Array(a);
           ++o < a;
 
         )
           i[o] = r[t + o]
         o = -1
         for (var l = Array(t + 1); ++o < t; ) l[o] = r[o]
-        return (l[t] = n(i)), Wk(e, this, l)
+        return (l[t] = n(i)), $k(e, this, l)
       }
     )
   }
-  var Bk = function (e) {
+  var Kk = function (e) {
       return function () {
         return e
       }
     },
-    $k = Zh,
-    Yk = (function () {
+    Qk = Zh,
+    Xk = (function () {
       try {
-        var e = $k(Object, 'defineProperty')
+        var e = Qk(Object, 'defineProperty')
         return e({}, '', {}), e
       } catch (e) {}
     })(),
-    qk = Bk,
-    Kk = Yk,
-    Qk = Kk
+    Gk = Kk,
+    Jk = Xk,
+    Zk = Jk
       ? function (e, t) {
-          return Kk(e, 'toString', {
+          return Jk(e, 'toString', {
             configurable: !0,
             enumerable: !1,
-            value: qk(t),
+            value: Gk(t),
             writable: !0,
           })
         }
-      : Dw,
-    Xk = Date.now
-  var Gk = function (e) {
+      : _w,
+    eE = Date.now
+  var tE = function (e) {
       var t = 0,
         n = 0
       return function () {
-        var r = Xk(),
+        var r = eE(),
           o = 16 - (r - n)
         if (((n = r), o > 0)) {
           if (++t >= 800) return arguments[0]
@@ -14446,27 +14613,27 @@
         return e.apply(void 0, arguments)
       }
     },
-    Jk = Gk(Qk),
-    Zk = Dw,
-    eE = Vk,
-    tE = Jk
-  var nE = function (e, t) {
-      return tE(eE(e, t, Zk), e + '')
+    nE = tE(Zk),
+    rE = _w,
+    oE = qk,
+    aE = nE
+  var iE = function (e, t) {
+      return aE(oE(e, t, rE), e + '')
     },
-    rE = Ek,
-    oE = Uk,
-    aE = hn,
-    iE = nE(function (e, t) {
+    lE = xk,
+    uE = Bk,
+    sE = hn,
+    cE = iE(function (e, t) {
       if (null == e) return []
       var n = t.length
       return (
-        n > 1 && aE(e, t[0], t[1])
+        n > 1 && sE(e, t[0], t[1])
           ? (t = [])
-          : n > 2 && aE(t[0], t[1], t[2]) && (t = [t[0]]),
-        oE(e, rE(t, 1), [])
+          : n > 2 && sE(t[0], t[1], t[2]) && (t = [t[0]]),
+        uE(e, lE(t, 1), [])
       )
     }),
-    lE = (function () {
+    fE = (function () {
       function e(t, n) {
         var r = n.accessors,
           o = n.slotMetrics
@@ -14530,12 +14697,12 @@
         e
       )
     })()
-  function uE(e, t, n) {
+  function dE(e, t, n) {
     return (
       Math.abs(t.start - e.start) < n || (t.start > e.start && t.start < e.end)
     )
   }
-  function sE(e) {
+  function pE(e) {
     for (
       var t = e.events,
         n = e.minimumStartDifference,
@@ -14543,7 +14710,7 @@
         o = e.accessors,
         a = (function (e) {
           for (
-            var t = iE(e, [
+            var t = cE(e, [
                 'startMs',
                 function (e) {
                   return -e.endMs
@@ -14569,7 +14736,7 @@
           return n
         })(
           t.map(function (e) {
-            return new lE(e, { slotMetrics: r, accessors: o })
+            return new fE(e, { slotMetrics: r, accessors: o })
           })
         ),
         i = [],
@@ -14581,7 +14748,7 @@
           if (!t) return (e.rows = []), i.push(e), 'continue'
           e.container = t
           for (var r = null, o = t.rows.length - 1; !r && o >= 0; o--)
-            uE(t.rows[o], e, n) && (r = t.rows[o])
+            dE(t.rows[o], e, n) && (r = t.rows[o])
           r
             ? (r.leaves.push(e), (e.row = r))
             : ((e.leaves = []), t.rows.push(e))
@@ -14603,19 +14770,19 @@
       }
     })
   }
-  function cE(e, t, n) {
+  function vE(e, t, n) {
     for (var r = 0; r < e.friends.length; ++r)
       if (!(n.indexOf(e.friends[r]) > -1)) {
         ;(t = t > e.friends[r].idx ? t : e.friends[r].idx), n.push(e.friends[r])
-        var o = cE(e.friends[r], t, n)
+        var o = vE(e.friends[r], t, n)
         t = t > o ? t : o
       }
     return t
   }
-  var fE = {
-    overlap: sE,
+  var hE = {
+    overlap: pE,
     'no-overlap': function (e) {
-      var t = sE({
+      var t = pE({
         events: e.events,
         minimumStartDifference: e.minimumStartDifference,
         slotMetrics: e.slotMetrics,
@@ -14665,7 +14832,7 @@
         var g
         if (!t[m].size) {
           var y = []
-          ;(g = 100 / (cE(t[m], 0, y) + 1)), (t[m].size = g)
+          ;(g = 100 / (vE(t[m], 0, y) + 1)), (t[m].size = g)
           for (var b = 0; b < y.length; ++b) y[b].size = g
         }
       }
@@ -14677,169 +14844,38 @@
           E = E > D ? E : D
         }
         E <= k.idx && (k.size = 100 - k.idx * k.size)
-        var x = 0 === k.idx ? 0 : 3
-        ;(k.style.width = 'calc('.concat(k.size, '% - ').concat(x, 'px)')),
+        var _ = 0 === k.idx ? 0 : 3
+        ;(k.style.width = 'calc('.concat(k.size, '% - ').concat(_, 'px)')),
           (k.style.height = 'calc('.concat(k.style.height, '% - 2px)')),
           (k.style.xOffset = 'calc('
             .concat(k.style.left, '% + ')
-            .concat(x, 'px)'))
+            .concat(_, 'px)'))
       }
       return t
     },
   }
-  function dE(e) {
+  function mE(e) {
     return !!(e && e.constructor && e.call && e.apply)
   }
-  function pE(e) {
+  function gE(e) {
     e.events, e.minimumStartDifference, e.slotMetrics, e.accessors
     var t = e.dayLayoutAlgorithm,
       n = t
-    return t in fE && (n = fE[t]), dE(n) ? n.apply(this, arguments) : []
+    return t in hE && (n = hE[t]), mE(n) ? n.apply(this, arguments) : []
   }
-  var vE = (function (e) {
-    p(r, e)
-    var n = g(r)
-    function r() {
-      return s(this, r), n.apply(this, arguments)
-    }
-    return (
-      f(r, [
-        {
-          key: 'render',
-          value: function () {
-            var e = this.props,
-              n = e.renderSlot,
-              r = e.resource,
-              o = e.group,
-              a = e.getters,
-              i = e.components,
-              l = void 0 === i ? {} : i,
-              u = l.timeSlotWrapper,
-              s = void 0 === u ? t : u,
-              c = l.slotChildrenWrapper,
-              f = a ? a.slotGroupProp(o) : {}
-            return se.createElement(
-              'div',
-              Object.assign({ className: 'rbc-timeslot-group' }, f),
-              o.map(function (e, t) {
-                var o = a ? a.slotProp(e, r) : {}
-                return se.createElement(
-                  s,
-                  { key: t, value: e, resource: r },
-                  se.createElement(
-                    'div',
-                    Object.assign({}, o, {
-                      className: be('rbc-time-slot', o.className),
-                    }),
-                    n ? n(e, t) : null == c ? void 0 : c(o)
-                  )
-                )
-              })
-            )
-          },
-        },
-      ]),
-      r
-    )
-  })(x.Component)
-  function hE(e) {
-    return 'string' == typeof e ? e : e + '%'
-  }
-  function mE(e) {
-    var t = e.style,
-      n = e.className,
-      r = e.event,
-      a = e.accessors,
-      l = e.rtl,
-      u = e.selected,
-      s = e.label,
-      c = e.continuesPrior,
-      f = e.continuesAfter,
-      d = e.getters,
-      p = e.onClick,
-      v = e.onDoubleClick,
-      h = e.isBackgroundEvent,
-      m = e.onKeyPress,
-      g = e.components,
-      y = g.event,
-      b = g.eventWrapper,
-      w = a.title(r),
-      k = a.tooltip(r),
-      E = a.end(r),
-      S = a.start(r),
-      D = d.eventProp(r, S, E, u),
-      x = t.height,
-      O = t.top,
-      _ = t.width,
-      M = t.xOffset,
-      C = [
-        se.createElement('div', { key: '1', className: 'rbc-event-label' }, s),
-        se.createElement(
-          'div',
-          { key: '2', className: 'rbc-event-content' },
-          y ? se.createElement(y, { event: r, title: w }) : w
-        ),
-      ],
-      T = i(
-        i({}, D.style),
-        {},
-        h
-          ? o(
-              {
-                top: hE(O),
-                height: hE(x),
-                width: 'calc('.concat(_, ' + 10px)'),
-              },
-              l ? 'right' : 'left',
-              hE(Math.max(0, M))
-            )
-          : o(
-              { top: hE(O), width: hE(_), height: hE(x) },
-              l ? 'right' : 'left',
-              hE(M)
-            )
-      )
-    return se.createElement(
-      b,
-      Object.assign({ type: 'time' }, e),
-      se.createElement(
-        'div',
-        {
-          role: 'button',
-          tabIndex: 0,
-          onClick: p,
-          onDoubleClick: v,
-          style: T,
-          onKeyPress: m,
-          title: k ? ('string' == typeof s ? s + ': ' : '') + k : void 0,
-          className: be(
-            h ? 'rbc-background-event' : 'rbc-event',
-            n,
-            D.className,
-            {
-              'rbc-selected': u,
-              'rbc-event-continues-earlier': c,
-              'rbc-event-continues-later': f,
-            }
-          ),
-        },
-        C
-      )
-    )
-  }
-  var gE = function (e) {
+  var yE = function (e) {
       var t = e.children,
         n = e.className,
         r = e.style,
         o = e.innerRef
       return se.createElement('div', { className: n, style: r, ref: o }, t)
     },
-    yE = se.forwardRef(function (e, t) {
-      return se.createElement(gE, Object.assign({}, e, { innerRef: t }))
+    bE = se.forwardRef(function (e, t) {
+      return se.createElement(yE, Object.assign({}, e, { innerRef: t }))
     }),
-    bE = ['dayProp'],
-    wE = ['eventContainerWrapper'],
-    kE = (function (e) {
+    wE = ['dayProp'],
+    kE = ['eventContainerWrapper'],
+    EE = (function (e) {
       p(n, e)
       var t = g(n)
       function n() {
@@ -14869,7 +14905,7 @@
               m = o.resizable,
               g = h(e).slotMetrics,
               y = s.messages
-            return pE({
+            return gE({
               events: n,
               accessors: u,
               slotMetrics: g,
@@ -14890,7 +14926,7 @@
                 (o = w && k ? y.allDay : s.format({ start: h, end: v }, b))
               var E = w || g.startsBefore(h),
                 S = k || g.startsAfter(v)
-              return se.createElement(mE, {
+              return se.createElement(bk, {
                 style: p,
                 event: d,
                 label: o,
@@ -14925,7 +14961,7 @@
               n = e.props,
               r = n.longPressThreshold,
               o = n.localizer,
-              a = (e._selector = new db(
+              a = (e._selector = new pb(
                 function () {
                   return t
                 },
@@ -14948,7 +14984,7 @@
                   e.setState(a)
               },
               u = function (n) {
-                var r = e.slotMetrics.closestSlotFromPoint(n, vb(t))
+                var r = e.slotMetrics.closestSlotFromPoint(n, hb(t))
                 e.state.selecting || (e._initialSlot = r)
                 var a = e._initialSlot
                 o.lte(a, r)
@@ -14966,7 +15002,7 @@
                 )
               },
               s = function (t, n) {
-                if (!sb(e.containerRef.current, t)) {
+                if (!cb(e.containerRef.current, t)) {
                   var r = u(t),
                     o = r.startDate,
                     a = r.endDate
@@ -14978,7 +15014,7 @@
               a.on('selectStart', l),
               a.on('beforeSelect', function (t) {
                 if ('ignoreEvents' === e.props.selectable)
-                  return !sb(e.containerRef.current, t)
+                  return !cb(e.containerRef.current, t)
               }),
               a.on('click', function (e) {
                 return s(e, 'click')
@@ -15013,7 +15049,7 @@
 
             )
               u.push(l), (l = new Date(+l + 60 * e.props.step * 1e3))
-            _e(e.props.onSelectSlot, {
+            Oe(e.props.onSelectSlot, {
               slots: u,
               start: n,
               end: r,
@@ -15026,20 +15062,20 @@
           (e._select = function () {
             for (var t = arguments.length, n = new Array(t), r = 0; r < t; r++)
               n[r] = arguments[r]
-            _e(e.props.onSelectEvent, n)
+            Oe(e.props.onSelectEvent, n)
           }),
           (e._doubleClick = function () {
             for (var t = arguments.length, n = new Array(t), r = 0; r < t; r++)
               n[r] = arguments[r]
-            _e(e.props.onDoubleClickEvent, n)
+            Oe(e.props.onDoubleClickEvent, n)
           }),
           (e._keyPress = function () {
             for (var t = arguments.length, n = new Array(t), r = 0; r < t; r++)
               n[r] = arguments[r]
-            _e(e.props.onKeyPressEvent, n)
+            Oe(e.props.onKeyPressEvent, n)
           }),
-          (e.slotMetrics = mk(e.props)),
-          (e.containerRef = x.createRef()),
+          (e.slotMetrics = gk(e.props)),
+          (e.containerRef = _.createRef()),
           e
         )
       }
@@ -15144,10 +15180,10 @@
                 l = e.localizer,
                 s = e.getters,
                 c = s.dayProp,
-                f = u(s, bE),
+                f = u(s, wE),
                 d = e.components,
                 p = d.eventContainerWrapper,
-                v = u(d, wE),
+                v = u(d, kE),
                 h = this.slotMetrics,
                 m = this.state,
                 g = m.selecting,
@@ -15157,7 +15193,7 @@
                 k = c(n),
                 E = k.className,
                 S = k.style,
-                D = v.dayColumnWrapper || yE
+                D = v.dayColumnWrapper || bE
               return se.createElement(
                 D,
                 {
@@ -15175,7 +15211,7 @@
                   slotMetrics: h,
                 },
                 h.groups.map(function (e, t) {
-                  return se.createElement(vE, {
+                  return se.createElement(wk, {
                     key: t,
                     group: e,
                     resource: a,
@@ -15231,8 +15267,8 @@
         n
       )
     })(se.Component)
-  kE.defaultProps = { dragThroughEvents: !0, timeslots: 2 }
-  var EE = function (e) {
+  EE.defaultProps = { dragThroughEvents: !0, timeslots: 2 }
+  var SE = function (e) {
       var t = e.min,
         n = e.max,
         r = e.timeslots,
@@ -15244,7 +15280,7 @@
         s = e.getters,
         c = e.gutterRef,
         f = u.timeGutterWrapper,
-        d = x.useMemo(
+        d = _.useMemo(
           function () {
             return (function (e) {
               var t = e.min,
@@ -15264,14 +15300,14 @@
         p = d.start,
         v = d.end,
         h = E(
-          x.useState(
-            mk({ min: p, max: v, timeslots: r, step: o, localizer: a })
+          _.useState(
+            gk({ min: p, max: v, timeslots: r, step: o, localizer: a })
           ),
           2
         ),
         m = h[0],
         g = h[1]
-      x.useEffect(
+      _.useEffect(
         function () {
           m &&
             g(m.update({ min: p, max: v, timeslots: r, step: o, localizer: a }))
@@ -15283,7 +15319,7 @@
           o,
         ]
       )
-      var y = x.useCallback(
+      var y = _.useCallback(
         function (e, t) {
           if (t) return null
           var n = m.dateIsInGroup(i(), t)
@@ -15302,7 +15338,7 @@
           'div',
           { className: 'rbc-time-gutter rbc-time-column', ref: c },
           m.groups.map(function (e, t) {
-            return se.createElement(vE, {
+            return se.createElement(wk, {
               key: t,
               group: e,
               resource: l,
@@ -15314,10 +15350,10 @@
         )
       )
     },
-    SE = se.forwardRef(function (e, t) {
-      return se.createElement(EE, Object.assign({ gutterRef: t }, e))
+    DE = se.forwardRef(function (e, t) {
+      return se.createElement(SE, Object.assign({ gutterRef: t }, e))
     }),
-    DE = function (e) {
+    _E = function (e) {
       var t = e.label
       return se.createElement(se.Fragment, null, t)
     },
@@ -15332,7 +15368,7 @@
         return (
           ((e = t.call.apply(t, [this].concat(o))).handleHeaderClick =
             function (t, n, r) {
-              r.preventDefault(), _e(e.props.onDrillDown, [t, n])
+              r.preventDefault(), Oe(e.props.onDrillDown, [t, n])
             }),
           (e.renderRow = function (t) {
             var n = e.props,
@@ -15352,7 +15388,7 @@
                     return c.resource(e) === p
                   })
                 : r
-            return se.createElement(sk, {
+            return se.createElement(ck, {
               isAllDay: !0,
               rtl: o,
               getNow: i,
@@ -15392,7 +15428,7 @@
                 a = n.getNow,
                 i = n.getters.dayProp,
                 l = n.components.header,
-                u = void 0 === l ? ck : l,
+                u = void 0 === l ? fk : l,
                 s = a()
               return e.map(function (e, n) {
                 var a = o(e),
@@ -15450,7 +15486,7 @@
                 h = t.components,
                 m = h.timeGutterHeader,
                 g = h.resourceHeader,
-                y = void 0 === g ? DE : g,
+                y = void 0 === g ? _E : g,
                 b = t.resizable,
                 w = {}
               v &&
@@ -15509,7 +15545,7 @@
                       },
                       e.renderHeaderCells(a)
                     ),
-                    se.createElement(sk, {
+                    se.createElement(ck, {
                       isAllDay: !0,
                       rtl: r,
                       getNow: l,
@@ -15546,8 +15582,8 @@
     var n = Qn(e)
     return n ? n.innerWidth : t ? e.clientWidth : Zn(e).width
   }
-  var _E = {}
-  var ME = (function (e) {
+  var ME = {}
+  var CE = (function (e) {
     p(n, e)
     var t = g(n)
     function n(e) {
@@ -15565,19 +15601,19 @@
           r.clearSelection()
           for (var e = arguments.length, t = new Array(e), n = 0; n < e; n++)
             t[n] = arguments[n]
-          _e(r.props.onKeyPressEvent, t)
+          Oe(r.props.onKeyPressEvent, t)
         }),
         (r.handleSelectEvent = function () {
           r.clearSelection()
           for (var e = arguments.length, t = new Array(e), n = 0; n < e; n++)
             t[n] = arguments[n]
-          _e(r.props.onSelectEvent, t)
+          Oe(r.props.onSelectEvent, t)
         }),
         (r.handleDoubleClickEvent = function () {
           r.clearSelection()
           for (var e = arguments.length, t = new Array(e), n = 0; n < e; n++)
             t[n] = arguments[n]
-          _e(r.props.onDoubleClickEvent, t)
+          Oe(r.props.onDoubleClickEvent, t)
         }),
         (r.handleShowMore = function (e, t, n, o, a) {
           var l = r.props,
@@ -15596,15 +15632,15 @@
                 target: a,
               },
             })
-          } else d && _e(s, [t, f(t) || xe.DAY])
-          _e(c, [e, t, o])
+          } else d && Oe(s, [t, f(t) || _e.DAY])
+          Oe(c, [e, t, o])
         }),
         (r.handleSelectAllDaySlot = function (e, t) {
           var n = r.props.onSelectSlot,
             o = new Date(e[0]),
             a = new Date(e[e.length - 1])
           a.setDate(e[e.length - 1].getDate() + 1),
-            _e(n, {
+            Oe(n, {
               slots: e,
               start: o,
               end: a,
@@ -15628,7 +15664,7 @@
             }
           }
         }),
-        (r.memoizedResources = ik(function (e, t) {
+        (r.memoizedResources = lk(function (e, t) {
           return (function (e, t) {
             return {
               map: function (n) {
@@ -15636,13 +15672,13 @@
                   ? e.map(function (e, r) {
                       return n([t.resourceId(e), e], r)
                     })
-                  : [n([_E, null], 0)]
+                  : [n([ME, null], 0)]
               },
               groupEvents: function (n) {
                 var r = new Map()
                 return e
                   ? (n.forEach(function (e) {
-                      var n = t.resource(e) || _E
+                      var n = t.resource(e) || ME
                       if (Array.isArray(n))
                         n.forEach(function (t) {
                           var n = r.get(t) || []
@@ -15654,7 +15690,7 @@
                       }
                     }),
                     r)
-                  : (r.set(_E, n), r)
+                  : (r.set(ME, n), r)
               },
             }
           })(e, t)
@@ -15664,7 +15700,7 @@
         (r.contentRef = se.createRef()),
         (r.containerRef = se.createRef()),
         (r._scrollRatio = null),
-        (r.gutterRef = x.createRef()),
+        (r.gutterRef = _.createRef()),
         r
       )
     }
@@ -15728,7 +15764,7 @@
                     return c.inRange(e, s.start(t), s.end(t), 'day')
                   })
                 return se.createElement(
-                  kE,
+                  EE,
                   Object.assign({}, o.props, {
                     localizer: c,
                     min: c.merge(e, i),
@@ -15778,7 +15814,7 @@
               S = []
             return (
               n.forEach(function (e) {
-                if (Vw(e, b, w, f, p)) {
+                if (Bw(e, b, w, f, p)) {
                   var t = f.start(e),
                     n = f.end(e)
                   f.allDay(e) ||
@@ -15789,10 +15825,10 @@
                 }
               }),
               r.forEach(function (e) {
-                Vw(e, b, w, f, p) && S.push(e)
+                Bw(e, b, w, f, p) && S.push(e)
               }),
               k.sort(function (e, t) {
-                return $w(e, t, f, p)
+                return Yw(e, t, f, p)
               }),
               se.createElement(
                 'div',
@@ -15841,7 +15877,7 @@
                     className: 'rbc-time-content',
                     onScroll: this.handleScroll,
                   },
-                  se.createElement(SE, {
+                  se.createElement(DE, {
                     date: b,
                     ref: this.gutterRef,
                     localizer: p,
@@ -15962,9 +15998,9 @@
       ]),
       n
     )
-  })(x.Component)
-  ME.defaultProps = { step: 30, timeslots: 2 }
-  var CE = [
+  })(_.Component)
+  CE.defaultProps = { step: 30, timeslots: 2 }
+  var TE = [
       'date',
       'localizer',
       'min',
@@ -15972,7 +16008,7 @@
       'scrollToTime',
       'enableAutoScroll',
     ],
-    TE = (function (e) {
+    PE = (function (e) {
       p(n, e)
       var t = g(n)
       function n() {
@@ -15994,10 +16030,10 @@
                 c = void 0 === s ? r.startOf(new Date(), 'day') : s,
                 f = e.enableAutoScroll,
                 d = void 0 === f || f,
-                p = u(e, CE),
+                p = u(e, TE),
                 v = n.range(t, { localizer: r })
               return se.createElement(
-                ME,
+                CE,
                 Object.assign({}, p, {
                   range: v,
                   eventOffset: 10,
@@ -16014,13 +16050,13 @@
         n
       )
     })(se.Component)
-  function PE(e) {
+  function RE(e) {
     return y(e) || zt(e) || w(e) || k()
   }
-  ;(TE.range = function (e, t) {
+  ;(PE.range = function (e, t) {
     return [t.localizer.startOf(e, 'day')]
   }),
-    (TE.navigate = function (e, t, n) {
+    (PE.navigate = function (e, t, n) {
       var r = n.localizer
       switch (t) {
         case De.PREVIOUS:
@@ -16031,10 +16067,10 @@
           return e
       }
     }),
-    (TE.title = function (e, t) {
+    (PE.title = function (e, t) {
       return t.localizer.format(e, 'dayHeaderFormat')
     })
-  var RE = [
+  var NE = [
       'date',
       'localizer',
       'min',
@@ -16042,7 +16078,7 @@
       'scrollToTime',
       'enableAutoScroll',
     ],
-    NE = (function (e) {
+    zE = (function (e) {
       p(n, e)
       var t = g(n)
       function n() {
@@ -16064,10 +16100,10 @@
                 c = void 0 === s ? r.startOf(new Date(), 'day') : s,
                 f = e.enableAutoScroll,
                 d = void 0 === f || f,
-                p = u(e, RE),
+                p = u(e, NE),
                 v = n.range(t, this.props)
               return se.createElement(
-                ME,
+                CE,
                 Object.assign({}, p, {
                   range: v,
                   eventOffset: 15,
@@ -16084,8 +16120,8 @@
         n
       )
     })(se.Component)
-  ;(NE.defaultProps = ME.defaultProps),
-    (NE.navigate = function (e, t, n) {
+  ;(zE.defaultProps = CE.defaultProps),
+    (zE.navigate = function (e, t, n) {
       var r = n.localizer
       switch (t) {
         case De.PREVIOUS:
@@ -16096,21 +16132,21 @@
           return e
       }
     }),
-    (NE.range = function (e, t) {
+    (zE.range = function (e, t) {
       var n = t.localizer,
         r = n.startOfWeek(),
         o = n.startOf(e, 'week', r),
         a = n.endOf(e, 'week', r)
       return n.range(o, a)
     }),
-    (NE.title = function (e, t) {
+    (zE.title = function (e, t) {
       var n = t.localizer,
-        r = PE(NE.range(e, { localizer: n })),
+        r = RE(zE.range(e, { localizer: n })),
         o = r[0],
         a = r.slice(1)
       return n.format({ start: o, end: a.pop() }, 'dayRangeHeaderFormat')
     })
-  var zE = [
+  var LE = [
     'date',
     'localizer',
     'min',
@@ -16118,13 +16154,13 @@
     'scrollToTime',
     'enableAutoScroll',
   ]
-  function LE(e, t) {
-    return NE.range(e, t).filter(function (e) {
+  function jE(e, t) {
+    return zE.range(e, t).filter(function (e) {
       return -1 === [6, 0].indexOf(e.getDay())
     })
   }
-  var jE,
-    AE = (function (e) {
+  var AE,
+    FE = (function (e) {
       p(n, e)
       var t = g(n)
       function n() {
@@ -16146,10 +16182,10 @@
                 s = void 0 === l ? n.startOf(new Date(), 'day') : l,
                 c = e.enableAutoScroll,
                 f = void 0 === c || c,
-                d = u(e, zE),
-                p = LE(t, this.props)
+                d = u(e, LE),
+                p = jE(t, this.props)
               return se.createElement(
-                ME,
+                CE,
                 Object.assign({}, d, {
                   range: p,
                   eventOffset: 15,
@@ -16166,7 +16202,7 @@
         n
       )
     })(se.Component)
-  function FE(e) {
+  function IE(e) {
     var t = e.accessors,
       n = e.components,
       r = e.date,
@@ -16177,12 +16213,12 @@
       u = e.onDoubleClickEvent,
       s = e.onSelectEvent,
       c = e.selected,
-      f = x.useRef(null),
-      d = x.useRef(null),
-      p = x.useRef(null),
-      v = x.useRef(null),
-      h = x.useRef(null)
-    x.useEffect(function () {
+      f = _.useRef(null),
+      d = _.useRef(null),
+      p = _.useRef(null),
+      v = _.useRef(null),
+      h = _.useRef(null)
+    _.useEffect(function () {
       g()
     })
     var m = function (e, r) {
@@ -16264,7 +16300,7 @@
       w = l.range(r, b, 'day')
     return (
       (o = o.filter(function (e) {
-        return Vw(e, l.startOf(r, 'day'), l.endOf(b, 'day'), t, l)
+        return Bw(e, l.startOf(r, 'day'), l.endOf(b, 'day'), t, l)
       })).sort(function (e, n) {
         return +t.start(e) - +t.start(n)
       }),
@@ -16312,7 +16348,7 @@
                         var i = n.event,
                           f = n.date
                         return (r = r.filter(function (n) {
-                          return Vw(
+                          return Bw(
                             n,
                             l.startOf(e, 'day'),
                             l.endOf(e, 'day'),
@@ -16381,25 +16417,25 @@
       )
     )
   }
-  ;(AE.defaultProps = ME.defaultProps),
-    (AE.range = LE),
-    (AE.navigate = NE.navigate),
-    (AE.title = function (e, t) {
+  ;(FE.defaultProps = CE.defaultProps),
+    (FE.range = jE),
+    (FE.navigate = zE.navigate),
+    (FE.title = function (e, t) {
       var n = t.localizer,
-        r = PE(LE(e, { localizer: n })),
+        r = RE(jE(e, { localizer: n })),
         o = r[0],
         a = r.slice(1)
       return n.format({ start: o, end: a.pop() }, 'dayRangeHeaderFormat')
     }),
-    (FE.defaultProps = { length: 30 }),
-    (FE.range = function (e, t) {
+    (IE.defaultProps = { length: 30 }),
+    (IE.range = function (e, t) {
       var n = t.length,
-        r = void 0 === n ? FE.defaultProps.length : n
+        r = void 0 === n ? IE.defaultProps.length : n
       return { start: e, end: t.localizer.add(e, r, 'day') }
     }),
-    (FE.navigate = function (e, t, n) {
+    (IE.navigate = function (e, t, n) {
       var r = n.length,
-        o = void 0 === r ? FE.defaultProps.length : r,
+        o = void 0 === r ? IE.defaultProps.length : r,
         a = n.localizer
       switch (t) {
         case De.PREVIOUS:
@@ -16410,27 +16446,27 @@
           return e
       }
     }),
-    (FE.title = function (e, t) {
+    (IE.title = function (e, t) {
       var n = t.length,
-        r = void 0 === n ? FE.defaultProps.length : n,
+        r = void 0 === n ? IE.defaultProps.length : n,
         o = t.localizer,
         a = o.add(e, r, 'day')
       return o.format({ start: e, end: a }, 'agendaHeaderFormat')
     })
-  var IE =
-      (o((jE = {}), xe.MONTH, vk),
-      o(jE, xe.WEEK, NE),
-      o(jE, xe.WORK_WEEK, AE),
-      o(jE, xe.DAY, TE),
-      o(jE, xe.AGENDA, FE),
-      jE),
-    UE = ['action', 'date', 'today']
-  function WE(e, t) {
+  var UE =
+      (o((AE = {}), _e.MONTH, hk),
+      o(AE, _e.WEEK, zE),
+      o(AE, _e.WORK_WEEK, FE),
+      o(AE, _e.DAY, PE),
+      o(AE, _e.AGENDA, IE),
+      AE),
+    WE = ['action', 'date', 'today']
+  function HE(e, t) {
     var n = t.action,
       r = t.date,
       o = t.today,
-      a = u(t, UE)
-    switch (((e = 'string' == typeof e ? IE[e] : e), n)) {
+      a = u(t, WE)
+    switch (((e = 'string' == typeof e ? UE[e] : e), n)) {
       case De.TODAY:
         r = o || new Date()
         break
@@ -16445,7 +16481,7 @@
     }
     return r
   }
-  var HE = (function (e) {
+  var VE = (function (e) {
     p(n, e)
     var t = g(n)
     function n() {
@@ -16536,7 +16572,7 @@
       n
     )
   })(se.Component)
-  var VE = function (e, t) {
+  var BE = function (e, t) {
       for (
         var n = -1, r = null == e ? 0 : e.length;
         ++n < r && !1 !== t(e[n], n, e);
@@ -16544,69 +16580,69 @@
       );
       return e
     },
-    BE = Yk
-  var $E = function (e, t, n) {
-      '__proto__' == t && BE
-        ? BE(e, t, { configurable: !0, enumerable: !0, value: n, writable: !0 })
+    $E = Xk
+  var YE = function (e, t, n) {
+      '__proto__' == t && $E
+        ? $E(e, t, { configurable: !0, enumerable: !0, value: n, writable: !0 })
         : (e[t] = n)
     },
-    YE = $E,
-    qE = At,
-    KE = Object.prototype.hasOwnProperty
-  var QE = function (e, t, n) {
+    qE = YE,
+    KE = At,
+    QE = Object.prototype.hasOwnProperty
+  var XE = function (e, t, n) {
       var r = e[t]
-      ;(KE.call(e, t) && qE(r, n) && (void 0 !== n || t in e)) || YE(e, t, n)
+      ;(QE.call(e, t) && KE(r, n) && (void 0 !== n || t in e)) || qE(e, t, n)
     },
-    XE = QE,
-    GE = $E
-  var JE = function (e, t, n, r) {
+    GE = XE,
+    JE = YE
+  var ZE = function (e, t, n, r) {
       var o = !n
       n || (n = {})
       for (var a = -1, i = t.length; ++a < i; ) {
         var l = t[a],
           u = r ? r(n[l], e[l], l, n, e) : void 0
-        void 0 === u && (u = e[l]), o ? GE(n, l, u) : XE(n, l, u)
+        void 0 === u && (u = e[l]), o ? JE(n, l, u) : GE(n, l, u)
       }
       return n
     },
-    ZE = JE,
-    eS = uy
-  var tS = function (e, t) {
-    return e && ZE(t, eS(t), e)
+    eS = ZE,
+    tS = uy
+  var nS = function (e, t) {
+    return e && eS(t, tS(t), e)
   }
-  var nS = en,
-    rS = Zg,
-    oS = function (e) {
+  var rS = en,
+    oS = Zg,
+    aS = function (e) {
       var t = []
       if (null != e) for (var n in Object(e)) t.push(n)
       return t
     },
-    aS = Object.prototype.hasOwnProperty
-  var iS = Gg,
-    lS = function (e) {
-      if (!nS(e)) return oS(e)
-      var t = rS(e),
+    iS = Object.prototype.hasOwnProperty
+  var lS = Gg,
+    uS = function (e) {
+      if (!rS(e)) return aS(e)
+      var t = oS(e),
         n = []
       for (var r in e)
-        ('constructor' != r || (!t && aS.call(e, r))) && n.push(r)
+        ('constructor' != r || (!t && iS.call(e, r))) && n.push(r)
       return n
     },
-    uS = un
-  var sS = function (e) {
-      return uS(e) ? iS(e, !0) : lS(e)
+    sS = un
+  var cS = function (e) {
+      return sS(e) ? lS(e, !0) : uS(e)
     },
-    cS = JE,
-    fS = sS
-  var dS = function (e, t) {
-      return e && cS(t, fS(t), e)
+    fS = ZE,
+    dS = cS
+  var pS = function (e, t) {
+      return e && fS(t, dS(t), e)
     },
-    pS = {},
-    vS = {
+    vS = {},
+    hS = {
       get exports() {
-        return pS
+        return vS
       },
       set exports(e) {
-        pS = e
+        vS = e
       },
     }
   !(function (e, t) {
@@ -16621,90 +16657,90 @@
         r = i ? i(n) : new e.constructor(n)
       return e.copy(r), r
     }
-  })(vS, pS)
-  var hS = function (e, t) {
+  })(hS, vS)
+  var mS = function (e, t) {
       var n = -1,
         r = e.length
       for (t || (t = Array(r)); ++n < r; ) t[n] = e[n]
       return t
     },
-    mS = JE,
-    gS = yg
-  var yS = function (e, t) {
-      return mS(e, gS(e), t)
+    gS = ZE,
+    yS = yg
+  var bS = function (e, t) {
+      return gS(e, yS(e), t)
     },
-    bS = ey(Object.getPrototypeOf, Object),
-    wS = ug,
-    kS = bS,
-    ES = yg,
-    SS = pg,
-    DS = Object.getOwnPropertySymbols
+    wS = ey(Object.getPrototypeOf, Object),
+    kS = ug,
+    ES = wS,
+    SS = yg,
+    DS = pg,
+    _S = Object.getOwnPropertySymbols
       ? function (e) {
-          for (var t = []; e; ) wS(t, ES(e)), (e = kS(e))
+          for (var t = []; e; ) kS(t, SS(e)), (e = ES(e))
           return t
         }
-      : SS,
-    xS = JE,
-    OS = DS
-  var _S = function (e, t) {
+      : DS,
+    xS = ZE,
+    OS = _S
+  var MS = function (e, t) {
       return xS(e, OS(e), t)
     },
-    MS = dg,
-    CS = DS,
-    TS = sS
-  var PS = function (e) {
-      return MS(e, TS, CS)
+    CS = dg,
+    TS = _S,
+    PS = cS
+  var RS = function (e) {
+      return CS(e, PS, TS)
     },
-    RS = Object.prototype.hasOwnProperty
-  var NS = function (e) {
+    NS = Object.prototype.hasOwnProperty
+  var zS = function (e) {
       var t = e.length,
         n = new e.constructor(t)
       return (
         t &&
           'string' == typeof e[0] &&
-          RS.call(e, 'index') &&
+          NS.call(e, 'index') &&
           ((n.index = e.index), (n.input = e.input)),
         n
       )
     },
-    zS = Zm
-  var LS = function (e) {
+    LS = Zm
+  var jS = function (e) {
       var t = new e.constructor(e.byteLength)
-      return new zS(t).set(new zS(e)), t
+      return new LS(t).set(new LS(e)), t
     },
-    jS = LS
-  var AS = function (e, t) {
-      var n = t ? jS(e.buffer) : e.buffer
+    AS = jS
+  var FS = function (e, t) {
+      var n = t ? AS(e.buffer) : e.buffer
       return new e.constructor(n, e.byteOffset, e.byteLength)
     },
-    FS = /\w*$/
-  var IS = function (e) {
-      var t = new e.constructor(e.source, FS.exec(e))
+    IS = /\w*$/
+  var US = function (e) {
+      var t = new e.constructor(e.source, IS.exec(e))
       return (t.lastIndex = e.lastIndex), t
     },
-    US = Ht ? Ht.prototype : void 0,
-    WS = US ? US.valueOf : void 0
-  var HS = LS
-  var VS = LS,
-    BS = AS,
-    $S = IS,
-    YS = function (e) {
-      return WS ? Object(WS.call(e)) : {}
+    WS = Ht ? Ht.prototype : void 0,
+    HS = WS ? WS.valueOf : void 0
+  var VS = jS
+  var BS = jS,
+    $S = FS,
+    YS = US,
+    qS = function (e) {
+      return HS ? Object(HS.call(e)) : {}
     },
-    qS = function (e, t) {
-      var n = t ? HS(e.buffer) : e.buffer
+    KS = function (e, t) {
+      var n = t ? VS(e.buffer) : e.buffer
       return new e.constructor(n, e.byteOffset, e.length)
     }
-  var KS = function (e, t, n) {
+  var QS = function (e, t, n) {
       var r = e.constructor
       switch (t) {
         case '[object ArrayBuffer]':
-          return VS(e)
+          return BS(e)
         case '[object Boolean]':
         case '[object Date]':
           return new r(+e)
         case '[object DataView]':
-          return BS(e, n)
+          return $S(e, n)
         case '[object Float32Array]':
         case '[object Float64Array]':
         case '[object Int8Array]':
@@ -16714,7 +16750,7 @@
         case '[object Uint8ClampedArray]':
         case '[object Uint16Array]':
         case '[object Uint32Array]':
-          return qS(e, n)
+          return KS(e, n)
         case '[object Map]':
         case '[object Set]':
           return new r()
@@ -16722,252 +16758,252 @@
         case '[object String]':
           return new r(e)
         case '[object RegExp]':
-          return $S(e)
-        case '[object Symbol]':
           return YS(e)
+        case '[object Symbol]':
+          return qS(e)
       }
     },
-    QS = en,
-    XS = Object.create,
-    GS = (function () {
+    XS = en,
+    GS = Object.create,
+    JS = (function () {
       function e() {}
       return function (t) {
-        if (!QS(t)) return {}
-        if (XS) return XS(t)
+        if (!XS(t)) return {}
+        if (GS) return GS(t)
         e.prototype = t
         var n = new e()
         return (e.prototype = void 0), n
       }
     })(),
-    JS = GS,
-    ZS = bS,
-    eD = Zg
-  var tD = function (e) {
-      return 'function' != typeof e.constructor || eD(e) ? {} : JS(ZS(e))
+    ZS = JS,
+    eD = wS,
+    tD = Zg
+  var nD = function (e) {
+      return 'function' != typeof e.constructor || tD(e) ? {} : ZS(eD(e))
     },
-    nD = zy,
-    rD = bn
-  var oD = function (e) {
-      return rD(e) && '[object Map]' == nD(e)
+    rD = zy,
+    oD = bn
+  var aD = function (e) {
+      return oD(e) && '[object Map]' == rD(e)
     },
-    aD = Ag,
-    iD = Fg && Fg.isMap,
-    lD = iD ? aD(iD) : oD,
-    uD = zy,
-    sD = bn
-  var cD = function (e) {
-      return sD(e) && '[object Set]' == uD(e)
+    iD = Ag,
+    lD = Fg && Fg.isMap,
+    uD = lD ? iD(lD) : aD,
+    sD = zy,
+    cD = bn
+  var fD = function (e) {
+      return cD(e) && '[object Set]' == sD(e)
     },
-    fD = Ag,
-    dD = Fg && Fg.isSet,
-    pD = dD ? fD(dD) : cD,
-    vD = Bm,
-    hD = VE,
-    mD = QE,
-    gD = tS,
-    yD = dS,
+    dD = Ag,
+    pD = Fg && Fg.isSet,
+    vD = pD ? dD(pD) : fD,
+    hD = Bm,
+    mD = BE,
+    gD = XE,
+    yD = nS,
     bD = pS,
-    wD = hS,
-    kD = yS,
-    ED = _S,
-    SD = dy,
-    DD = PS,
+    wD = vS,
+    kD = mS,
+    ED = bS,
+    SD = MS,
+    DD = dy,
+    _D = RS,
     xD = zy,
-    OD = NS,
-    _D = KS,
-    MD = tD,
-    CD = sg,
-    TD = Cg,
-    PD = lD,
-    RD = en,
-    ND = pD,
-    zD = uy,
-    LD = sS,
-    jD = '[object Arguments]',
-    AD = '[object Function]',
-    FD = '[object Object]',
-    ID = {}
-  ;(ID[jD] =
-    ID['[object Array]'] =
-    ID['[object ArrayBuffer]'] =
-    ID['[object DataView]'] =
-    ID['[object Boolean]'] =
-    ID['[object Date]'] =
-    ID['[object Float32Array]'] =
-    ID['[object Float64Array]'] =
-    ID['[object Int8Array]'] =
-    ID['[object Int16Array]'] =
-    ID['[object Int32Array]'] =
-    ID['[object Map]'] =
-    ID['[object Number]'] =
-    ID[FD] =
-    ID['[object RegExp]'] =
-    ID['[object Set]'] =
-    ID['[object String]'] =
-    ID['[object Symbol]'] =
-    ID['[object Uint8Array]'] =
-    ID['[object Uint8ClampedArray]'] =
-    ID['[object Uint16Array]'] =
-    ID['[object Uint32Array]'] =
+    OD = zS,
+    MD = QS,
+    CD = nD,
+    TD = sg,
+    PD = Cg,
+    RD = uD,
+    ND = en,
+    zD = vD,
+    LD = uy,
+    jD = cS,
+    AD = '[object Arguments]',
+    FD = '[object Function]',
+    ID = '[object Object]',
+    UD = {}
+  ;(UD[AD] =
+    UD['[object Array]'] =
+    UD['[object ArrayBuffer]'] =
+    UD['[object DataView]'] =
+    UD['[object Boolean]'] =
+    UD['[object Date]'] =
+    UD['[object Float32Array]'] =
+    UD['[object Float64Array]'] =
+    UD['[object Int8Array]'] =
+    UD['[object Int16Array]'] =
+    UD['[object Int32Array]'] =
+    UD['[object Map]'] =
+    UD['[object Number]'] =
+    UD[ID] =
+    UD['[object RegExp]'] =
+    UD['[object Set]'] =
+    UD['[object String]'] =
+    UD['[object Symbol]'] =
+    UD['[object Uint8Array]'] =
+    UD['[object Uint8ClampedArray]'] =
+    UD['[object Uint16Array]'] =
+    UD['[object Uint32Array]'] =
       !0),
-    (ID['[object Error]'] = ID[AD] = ID['[object WeakMap]'] = !1)
-  var UD = function e(t, n, r, o, a, i) {
+    (UD['[object Error]'] = UD[FD] = UD['[object WeakMap]'] = !1)
+  var WD = function e(t, n, r, o, a, i) {
     var l,
       u = 1 & n,
       s = 2 & n,
       c = 4 & n
     if ((r && (l = a ? r(t, o, a, i) : r(t)), void 0 !== l)) return l
-    if (!RD(t)) return t
-    var f = CD(t)
+    if (!ND(t)) return t
+    var f = TD(t)
     if (f) {
-      if (((l = OD(t)), !u)) return wD(t, l)
+      if (((l = OD(t)), !u)) return kD(t, l)
     } else {
       var d = xD(t),
-        p = d == AD || '[object GeneratorFunction]' == d
-      if (TD(t)) return bD(t, u)
-      if (d == FD || d == jD || (p && !a)) {
-        if (((l = s || p ? {} : MD(t)), !u))
-          return s ? ED(t, yD(l, t)) : kD(t, gD(l, t))
+        p = d == FD || '[object GeneratorFunction]' == d
+      if (PD(t)) return wD(t, u)
+      if (d == ID || d == AD || (p && !a)) {
+        if (((l = s || p ? {} : CD(t)), !u))
+          return s ? SD(t, bD(l, t)) : ED(t, yD(l, t))
       } else {
-        if (!ID[d]) return a ? t : {}
-        l = _D(t, d, u)
+        if (!UD[d]) return a ? t : {}
+        l = MD(t, d, u)
       }
     }
-    i || (i = new vD())
+    i || (i = new hD())
     var v = i.get(t)
     if (v) return v
     i.set(t, l),
-      ND(t)
+      zD(t)
         ? t.forEach(function (o) {
             l.add(e(o, n, r, o, t, i))
           })
-        : PD(t) &&
+        : RD(t) &&
           t.forEach(function (o, a) {
             l.set(a, e(o, n, r, a, t, i))
           })
-    var h = f ? void 0 : (c ? (s ? DD : SD) : s ? LD : zD)(t)
+    var h = f ? void 0 : (c ? (s ? _D : DD) : s ? jD : LD)(t)
     return (
-      hD(h || t, function (o, a) {
-        h && (o = t[(a = o)]), mD(l, a, e(o, n, r, a, t, i))
+      mD(h || t, function (o, a) {
+        h && (o = t[(a = o)]), gD(l, a, e(o, n, r, a, t, i))
       }),
       l
     )
   }
-  var WD = lw,
-    HD = jt
-  var VD = nw,
-    BD = function (e) {
+  var HD = uw,
+    VD = jt
+  var BD = rw,
+    $D = function (e) {
       var t = null == e ? 0 : e.length
       return t ? e[t - 1] : void 0
     },
-    $D = function (e, t) {
-      return t.length < 2 ? e : WD(e, HD(t, 0, -1))
+    YD = function (e, t) {
+      return t.length < 2 ? e : HD(e, VD(t, 0, -1))
     },
-    YD = ow
-  var qD = function (e, t) {
-      return (t = VD(t, e)), null == (e = $D(e, t)) || delete e[YD(BD(t))]
+    qD = aw
+  var KD = function (e, t) {
+      return (t = BD(t, e)), null == (e = YD(e, t)) || delete e[qD($D(t))]
     },
-    KD = Zt,
-    QD = bS,
-    XD = bn,
-    GD = Function.prototype,
-    JD = Object.prototype,
-    ZD = GD.toString,
-    ex = JD.hasOwnProperty,
-    tx = ZD.call(Object)
-  var nx = function (e) {
-    if (!XD(e) || '[object Object]' != KD(e)) return !1
-    var t = QD(e)
+    QD = Zt,
+    XD = wS,
+    GD = bn,
+    JD = Function.prototype,
+    ZD = Object.prototype,
+    e_ = JD.toString,
+    t_ = ZD.hasOwnProperty,
+    n_ = e_.call(Object)
+  var r_ = function (e) {
+    if (!GD(e) || '[object Object]' != QD(e)) return !1
+    var t = XD(e)
     if (null === t) return !0
-    var n = ex.call(t, 'constructor') && t.constructor
-    return 'function' == typeof n && n instanceof n && ZD.call(n) == tx
+    var n = t_.call(t, 'constructor') && t.constructor
+    return 'function' == typeof n && n instanceof n && e_.call(n) == n_
   }
-  var rx = Ek
-  var ox = function (e) {
-      return (null == e ? 0 : e.length) ? rx(e, 1) : []
+  var o_ = xk
+  var a_ = function (e) {
+      return (null == e ? 0 : e.length) ? o_(e, 1) : []
     },
-    ax = Vk,
-    ix = Jk
-  var lx = Bb,
-    ux = UD,
-    sx = qD,
-    cx = nw,
-    fx = JE,
-    dx = function (e) {
-      return nx(e) ? void 0 : e
+    i_ = qk,
+    l_ = nE
+  var u_ = $b,
+    s_ = WD,
+    c_ = KD,
+    f_ = rw,
+    d_ = ZE,
+    p_ = function (e) {
+      return r_(e) ? void 0 : e
     },
-    px = PS,
-    vx = (function (e) {
-      return ix(ax(e, void 0, ox), e + '')
+    v_ = RS,
+    h_ = (function (e) {
+      return l_(i_(e, void 0, a_), e + '')
     })(function (e, t) {
       var n = {}
       if (null == e) return n
       var r = !1
-      ;(t = lx(t, function (t) {
-        return (t = cx(t, e)), r || (r = t.length > 1), t
+      ;(t = u_(t, function (t) {
+        return (t = f_(t, e)), r || (r = t.length > 1), t
       })),
-        fx(e, px(e), n),
-        r && (n = ux(n, 7, dx))
-      for (var o = t.length; o--; ) sx(n, t[o])
+        d_(e, v_(e), n),
+        r && (n = s_(n, 7, p_))
+      for (var o = t.length; o--; ) c_(n, t[o])
       return n
     }),
-    hx = nE,
-    mx = At,
-    gx = hn,
-    yx = sS,
-    bx = Object.prototype,
-    wx = bx.hasOwnProperty,
-    kx = hx(function (e, t) {
+    m_ = iE,
+    g_ = At,
+    y_ = hn,
+    b_ = cS,
+    w_ = Object.prototype,
+    k_ = w_.hasOwnProperty,
+    E_ = m_(function (e, t) {
       e = Object(e)
       var n = -1,
         r = t.length,
         o = r > 2 ? t[2] : void 0
-      for (o && gx(t[0], t[1], o) && (r = 1); ++n < r; )
-        for (var a = t[n], i = yx(a), l = -1, u = i.length; ++l < u; ) {
+      for (o && y_(t[0], t[1], o) && (r = 1); ++n < r; )
+        for (var a = t[n], i = b_(a), l = -1, u = i.length; ++l < u; ) {
           var s = i[l],
             c = e[s]
-          ;(void 0 === c || (mx(c, bx[s]) && !wx.call(e, s))) && (e[s] = a[s])
+          ;(void 0 === c || (g_(c, w_[s]) && !k_.call(e, s))) && (e[s] = a[s])
         }
       return e
     }),
-    Ex = VE,
-    Sx = GS,
-    Dx = xk,
-    xx = Lw,
-    Ox = bS,
-    _x = sg,
-    Mx = Cg,
-    Cx = rn,
-    Tx = en,
-    Px = Vg
-  var Rx = function (e, t, n) {
-      var r = _x(e),
-        o = r || Mx(e) || Px(e)
-      if (((t = xx(t)), null == n)) {
+    S_ = BE,
+    D_ = JS,
+    __ = Ck,
+    x_ = jw,
+    O_ = wS,
+    M_ = sg,
+    C_ = Cg,
+    T_ = rn,
+    P_ = en,
+    R_ = Vg
+  var N_ = function (e, t, n) {
+      var r = M_(e),
+        o = r || C_(e) || R_(e)
+      if (((t = x_(t)), null == n)) {
         var a = e && e.constructor
-        n = o ? (r ? new a() : []) : Tx(e) && Cx(a) ? Sx(Ox(e)) : {}
+        n = o ? (r ? new a() : []) : P_(e) && T_(a) ? D_(O_(e)) : {}
       }
       return (
-        (o ? Ex : Dx)(e, function (e, r, o) {
+        (o ? S_ : __)(e, function (e, r, o) {
           return t(n, e, r, o)
         }),
         n
       )
     },
-    Nx = $E,
-    zx = xk,
-    Lx = Lw
-  var jx = function (e, t) {
+    z_ = YE,
+    L_ = Ck,
+    j_ = jw
+  var A_ = function (e, t) {
     var n = {}
     return (
-      (t = Lx(t)),
-      zx(e, function (e, r, o) {
-        Nx(n, r, t(e, r, o))
+      (t = j_(t)),
+      L_(e, function (e, r, o) {
+        z_(n, r, t(e, r, o))
       }),
       n
     )
   }
-  var Ax = function (e) {
+  var F_ = function (e) {
       return function (t) {
         return (function (e, t) {
           var r = null
@@ -16984,8 +17020,8 @@
         })(t, e)
       }
     },
-    Fx = ['view', 'date', 'getNow', 'onNavigate'],
-    Ix = [
+    I_ = ['view', 'date', 'getNow', 'onNavigate'],
+    U_ = [
       'view',
       'toolbar',
       'events',
@@ -17004,7 +17040,7 @@
       'messages',
       'culture',
     ]
-  function Ux(e) {
+  function W_(e) {
     if (Array.isArray(e)) return e
     for (var t = [], n = 0, r = Object.entries(e); n < r.length; n++) {
       var o = E(r[n], 2),
@@ -17013,10 +17049,10 @@
     }
     return t
   }
-  function Wx(e, t) {
-    return -1 !== Ux(t.views).indexOf(e)
+  function H_(e, t) {
+    return -1 !== W_(t.views).indexOf(e)
   }
-  var Hx = (function (e) {
+  var V_ = (function (e) {
     p(o, e)
     var r = g(o)
     function o() {
@@ -17028,18 +17064,18 @@
         ((e = r.call.apply(r, [this].concat(a))).getViews = function () {
           var t = e.props.views
           return Array.isArray(t)
-            ? Rx(
+            ? N_(
                 t,
                 function (e, t) {
-                  return (e[t] = IE[t])
+                  return (e[t] = UE[t])
                 },
                 {}
               )
             : 'object' === n(t)
-            ? jx(t, function (e, t) {
-                return !0 === e ? IE[t] : e
+            ? A_(t, function (e, t) {
+                return !0 === e ? UE[t] : e
               })
-            : IE
+            : UE
         }),
         (e.getView = function () {
           return e.getViews()[e.props.view]
@@ -17063,11 +17099,11 @@
             a = r.date,
             l = r.getNow,
             s = r.onNavigate,
-            c = u(r, Fx),
+            c = u(r, I_),
             f = e.getView(),
             d = l()
           s(
-            (a = WE(
+            (a = HE(
               f,
               i(i({}, c), {}, { action: t, date: n || a || d, today: d })
             )),
@@ -17077,27 +17113,27 @@
             e.handleRangeChange(a, f)
         }),
         (e.handleViewChange = function (t) {
-          t !== e.props.view && Wx(t, e.props) && e.props.onView(t)
+          t !== e.props.view && H_(t, e.props) && e.props.onView(t)
           var n = e.getViews()
           e.handleRangeChange(e.props.date || e.props.getNow(), n[t], t)
         }),
         (e.handleSelectEvent = function () {
           for (var t = arguments.length, n = new Array(t), r = 0; r < t; r++)
             n[r] = arguments[r]
-          _e(e.props.onSelectEvent, n)
+          Oe(e.props.onSelectEvent, n)
         }),
         (e.handleDoubleClickEvent = function () {
           for (var t = arguments.length, n = new Array(t), r = 0; r < t; r++)
             n[r] = arguments[r]
-          _e(e.props.onDoubleClickEvent, n)
+          Oe(e.props.onDoubleClickEvent, n)
         }),
         (e.handleKeyPressEvent = function () {
           for (var t = arguments.length, n = new Array(t), r = 0; r < t; r++)
             n[r] = arguments[r]
-          _e(e.props.onKeyPressEvent, n)
+          Oe(e.props.onKeyPressEvent, n)
         }),
         (e.handleSelectSlot = function (t) {
-          _e(e.props.onSelectSlot, t)
+          Oe(e.props.onSelectSlot, t)
         }),
         (e.handleDrillDown = function (t, n) {
           var r = e.props.onDrillDown
@@ -17131,7 +17167,7 @@
                 p = e.onShowMore,
                 v = e.doShowMoreDrillDown
               e.components, e.formats, e.messages, e.culture
-              var h = u(e, Ix)
+              var h = u(e, U_)
               s = s || c()
               var m = this.getView(),
                 g = this.state.context,
@@ -17140,7 +17176,7 @@
                 w = g.getters,
                 k = g.localizer,
                 E = g.viewNames,
-                S = b.toolbar || HE,
+                S = b.toolbar || VE,
                 D = m.title(s, { localizer: k, length: f })
               return se.createElement(
                 'div',
@@ -17218,14 +17254,14 @@
                 E = e.components,
                 S = void 0 === E ? {} : E,
                 D = e.formats,
-                x = void 0 === D ? {} : D,
-                O = Ux(g)
+                _ = void 0 === D ? {} : D,
+                x = W_(g)
               return {
-                viewNames: O,
+                viewNames: x,
                 localizer: Rt(
                   y,
                   b,
-                  x,
+                  _,
                   (function (e) {
                     return i(i({}, Nt), e)
                   })(k)
@@ -17247,7 +17283,7 @@
                     return (h && h.apply(void 0, arguments)) || {}
                   },
                 },
-                components: kx(S[m] || {}, vx(S, O), {
+                components: E_(S[m] || {}, h_(S, x), {
                   eventWrapper: t,
                   backgroundEventWrapper: t,
                   eventContainerWrapper: t,
@@ -17260,14 +17296,14 @@
                   },
                 }),
                 accessors: {
-                  start: Ax(n),
-                  end: Ax(r),
-                  allDay: Ax(o),
-                  tooltip: Ax(a),
-                  title: Ax(l),
-                  resource: Ax(u),
-                  resourceId: Ax(s),
-                  resourceTitle: Ax(c),
+                  start: F_(n),
+                  end: F_(r),
+                  allDay: F_(o),
+                  tooltip: F_(a),
+                  title: F_(l),
+                  resource: F_(u),
+                  resourceId: F_(s),
+                  resourceTitle: F_(c),
                 },
               }
             },
@@ -17277,19 +17313,19 @@
       o
     )
   })(se.Component)
-  Hx.defaultProps = {
+  V_.defaultProps = {
     events: [],
     backgroundEvents: [],
     elementProps: {},
     popup: !1,
     toolbar: !0,
-    view: xe.MONTH,
-    views: [xe.MONTH, xe.WEEK, xe.DAY, xe.AGENDA],
+    view: _e.MONTH,
+    views: [_e.MONTH, _e.WEEK, _e.DAY, _e.AGENDA],
     step: 30,
     length: 30,
     allDayMaxRows: 1 / 0,
     doShowMoreDrillDown: !0,
-    drilldownView: xe.DAY,
+    drilldownView: _e.DAY,
     titleAccessor: 'title',
     tooltipAccessor: 'title',
     allDayAccessor: 'allDay',
@@ -17304,7 +17340,7 @@
     },
     dayLayoutAlgorithm: 'overlap',
   }
-  var Vx = (function e(t, n, r) {
+  var B_ = (function e(t, n, r) {
       void 0 === r && (r = [])
       var o,
         a = t.displayName || t.name || 'Component',
@@ -17517,18 +17553,18 @@
         }),
         f
       )
-    })(Hx, { view: 'onView', date: 'onNavigate', selected: 'onSelectEvent' }),
-    Bx = function (e, t, n) {
+    })(V_, { view: 'onView', date: 'onNavigate', selected: 'onSelectEvent' }),
+    $_ = function (e, t, n) {
       var r = e.start,
         o = e.end
       return n.format(r, 'LT', t) + ' – ' + n.format(o, 'LT', t)
     },
-    $x = {
+    Y_ = {
       dateFormat: 'DD',
       dayFormat: 'DD ddd',
       weekdayFormat: 'ddd',
-      selectRangeFormat: Bx,
-      eventTimeRangeFormat: Bx,
+      selectRangeFormat: $_,
+      eventTimeRangeFormat: $_,
       eventTimeRangeStartFormat: function (e, t, n) {
         var r = e.start
         return n.format(r, 'LT', t) + ' – '
@@ -17556,23 +17592,23 @@
       },
       agendaDateFormat: 'ddd MMM DD',
       agendaTimeFormat: 'LT',
-      agendaTimeRangeFormat: Bx,
+      agendaTimeRangeFormat: $_,
     }
-  function Yx(e) {
+  function q_(e) {
     var t = e ? e.toLowerCase() : e
     return 'FullYear' === t ? (t = 'year') : t || (t = void 0), t
   }
-  var qx = function (e, t, n) {
+  var K_ = function (e, t, n) {
       var r = e.start,
         o = e.end
       return n.format(r, 't', t) + ' – ' + n.format(o, 't', t)
     },
-    Kx = {
+    Q_ = {
       dateFormat: 'dd',
       dayFormat: 'dd EEE',
       weekdayFormat: 'EEE',
-      selectRangeFormat: qx,
-      eventTimeRangeFormat: qx,
+      selectRangeFormat: K_,
+      eventTimeRangeFormat: K_,
       eventTimeRangeStartFormat: function (e, t, n) {
         var r = e.start
         return n.format(r, 't', t) + ' – '
@@ -17600,9 +17636,9 @@
       },
       agendaDateFormat: 'EEE MMM dd',
       agendaTimeFormat: 't',
-      agendaTimeRangeFormat: qx,
+      agendaTimeRangeFormat: K_,
     }
-  function Qx(e) {
+  function X_(e) {
     var t = e
       ? (function (e) {
           return /s$/.test(e) ? e : e + 's'
@@ -17610,17 +17646,17 @@
       : e
     return 'FullYear' === t ? (t = 'year') : t || (t = void 0), t
   }
-  var Xx = function (e, t, n) {
+  var G_ = function (e, t, n) {
       var r = e.start,
         o = e.end
       return n.format(r, 't', t) + ' – ' + n.format(o, 't', t)
     },
-    Gx = {
+    J_ = {
       dateFormat: 'dd',
       dayFormat: 'ddd dd/MM',
       weekdayFormat: 'ddd',
-      selectRangeFormat: Xx,
-      eventTimeRangeFormat: Xx,
+      selectRangeFormat: G_,
+      eventTimeRangeFormat: G_,
       eventTimeRangeStartFormat: function (e, t, n) {
         var r = e.start
         return n.format(r, 't', t) + ' – '
@@ -17648,9 +17684,9 @@
       },
       agendaDateFormat: 'ddd MMM dd',
       agendaTimeFormat: 't',
-      agendaTimeRangeFormat: Xx,
+      agendaTimeRangeFormat: G_,
     }
-  function Jx(e) {
+  function Z_(e) {
     return new Pt({
       firstOfWeek: function (t) {
         return (
@@ -17661,13 +17697,13 @@
           0
         )
       },
-      formats: Gx,
+      formats: J_,
       format: function (t, n, r) {
         return e.format(t, n, r)
       },
     })
   }
-  var Zx = function (e, t, n) {
+  var ex = function (e, t, n) {
       var r = e.start,
         o = e.end
       return (
@@ -17676,12 +17712,12 @@
         n.format(o, { time: 'short' }, t)
       )
     },
-    eO = {
+    tx = {
       dateFormat: 'dd',
       dayFormat: 'eee dd/MM',
       weekdayFormat: 'eee',
-      selectRangeFormat: Zx,
-      eventTimeRangeFormat: Zx,
+      selectRangeFormat: ex,
+      eventTimeRangeFormat: ex,
       eventTimeRangeStartFormat: function (e, t, n) {
         var r = e.start
         return n.format(r, { time: 'short' }, t) + ' – '
@@ -17713,19 +17749,19 @@
       },
       agendaDateFormat: 'eee MMM dd',
       agendaTimeFormat: { time: 'short' },
-      agendaTimeRangeFormat: Zx,
+      agendaTimeRangeFormat: ex,
     }
-  var tO = function (e, t, n) {
+  var nx = function (e, t, n) {
       var r = e.start,
         o = e.end
       return ''.concat(n.format(r, 'p', t), ' – ').concat(n.format(o, 'p', t))
     },
-    nO = {
+    rx = {
       dateFormat: 'dd',
       dayFormat: 'dd eee',
       weekdayFormat: 'cccc',
-      selectRangeFormat: tO,
-      eventTimeRangeFormat: tO,
+      selectRangeFormat: nx,
+      eventTimeRangeFormat: nx,
       eventTimeRangeStartFormat: function (e, t, n) {
         var r = e.start
         return ''.concat(n.format(r, 'h:mma', t), ' – ')
@@ -17751,15 +17787,15 @@
       },
       agendaDateFormat: 'ccc MMM dd',
       agendaTimeFormat: 'p',
-      agendaTimeRangeFormat: tO,
+      agendaTimeRangeFormat: nx,
     },
-    rO = {},
-    oO = {
+    ox = {},
+    ax = {
       get exports() {
-        return rO
+        return ox
       },
       set exports(e) {
-        rO = e
+        ox = e
       },
     }
   !(function (e, t) {
@@ -17777,15 +17813,15 @@
         )
       }
     }
-  })(oO)
-  var aO = rO,
-    iO = {},
-    lO = {
+  })(ax)
+  var ix = ox,
+    lx = {},
+    ux = {
       get exports() {
-        return iO
+        return lx
       },
       set exports(e) {
-        iO = e
+        lx = e
       },
     }
   !(function (e, t) {
@@ -17794,15 +17830,15 @@
         return this.isSame(e, t) || this.isAfter(e, t)
       }
     }
-  })(lO)
-  var uO = iO,
-    sO = {},
-    cO = {
+  })(ux)
+  var sx = lx,
+    cx = {},
+    fx = {
       get exports() {
-        return sO
+        return cx
       },
       set exports(e) {
-        sO = e
+        cx = e
       },
     }
   !(function (e, t) {
@@ -17811,15 +17847,15 @@
         return this.isSame(e, t) || this.isBefore(e, t)
       }
     }
-  })(cO)
-  var fO = sO,
-    dO = {},
-    pO = {
+  })(fx)
+  var dx = cx,
+    px = {},
+    vx = {
       get exports() {
-        return dO
+        return px
       },
       set exports(e) {
-        dO = e
+        px = e
       },
     }
   !(function (e, t) {
@@ -17934,15 +17970,15 @@
           return a(i(), 'weekdaysMin', 'weekdays', 2, e)
         })
     }
-  })(pO)
-  var vO = dO,
-    hO = {},
-    mO = {
+  })(vx)
+  var hx = px,
+    mx = {},
+    gx = {
       get exports() {
-        return hO
+        return mx
       },
       set exports(e) {
-        hO = e
+        mx = e
       },
     }
   !(function (e, t) {
@@ -17985,15 +18021,15 @@
             return a.call(this, r)
           })
       })
-  })(mO)
-  var gO = hO,
-    yO = {},
-    bO = {
+  })(gx)
+  var yx = mx,
+    bx = {},
+    wx = {
       get exports() {
-        return yO
+        return bx
       },
       set exports(e) {
-        yO = e
+        bx = e
       },
     }
   !(function (e, t) {
@@ -18016,15 +18052,15 @@
           return r('isBefore', e)
         })
     }
-  })(bO)
-  var wO = yO,
-    kO = {},
-    EO = {
+  })(wx)
+  var kx = bx,
+    Ex = {},
+    Sx = {
       get exports() {
-        return kO
+        return Ex
       },
       set exports(e) {
-        kO = e
+        Ex = e
       },
     }
   !(function (e, t) {
@@ -18131,19 +18167,19 @@
         }
       }
     })()
-  })(EO)
-  var SO = kO,
-    DO = function (e, t, n) {
+  })(Sx)
+  var Dx = Ex,
+    _x = function (e, t, n) {
       var r = e.start,
         o = e.end
       return n.format(r, 'LT', t) + ' – ' + n.format(o, 'LT', t)
     },
-    xO = {
+    xx = {
       dateFormat: 'DD',
       dayFormat: 'DD ddd',
       weekdayFormat: 'ddd',
-      selectRangeFormat: DO,
-      eventTimeRangeFormat: DO,
+      selectRangeFormat: _x,
+      eventTimeRangeFormat: _x,
       eventTimeRangeStartFormat: function (e, t, n) {
         var r = e.start
         return n.format(r, 'LT', t) + ' – '
@@ -18171,25 +18207,25 @@
       },
       agendaDateFormat: 'ddd MMM DD',
       agendaTimeFormat: 'LT',
-      agendaTimeRangeFormat: DO,
+      agendaTimeRangeFormat: _x,
     }
-  function OO(e) {
+  function Ox(e) {
     var t = e ? e.toLowerCase() : e
     return 'FullYear' === t ? (t = 'year') : t || (t = void 0), t
   }
-  var _O = { eventWrapper: t, timeSlotWrapper: t, dateCellWrapper: t }
-  ;(e.Calendar = Vx),
+  var Mx = { eventWrapper: t, timeSlotWrapper: t, dateCellWrapper: t }
+  ;(e.Calendar = B_),
     (e.DateLocalizer = Pt),
     (e.Navigate = De),
-    (e.Views = xe),
-    (e.components = _O),
+    (e.Views = _e),
+    (e.components = Mx),
     (e.dateFnsLocalizer = function (e) {
       var t = e.startOfWeek,
         n = e.getDay,
         r = e.format,
         o = e.locales
       return new Pt({
-        formats: nO,
+        formats: rx,
         firstOfWeek: function (e) {
           return n(t(new Date(), { locale: o[e] }))
         },
@@ -18199,13 +18235,13 @@
       })
     }),
     (e.dayjsLocalizer = function (e) {
-      e.extend(aO),
-        e.extend(uO),
-        e.extend(fO),
-        e.extend(vO),
-        e.extend(gO),
-        e.extend(wO),
-        e.extend(SO)
+      e.extend(ix),
+        e.extend(sx),
+        e.extend(dx),
+        e.extend(hx),
+        e.extend(yx),
+        e.extend(kx),
+        e.extend(Dx)
       var t = e.tz ? e.tz : e
       function n(n, r) {
         var o,
@@ -18218,7 +18254,7 @@
         return -t.tz(+a, l).utcOffset() - -t.tz(+i, l).utcOffset()
       }
       function r(e, n, r) {
-        var o = OO(r)
+        var o = Ox(r)
         return [o ? t(e).startOf(o) : t(e), o ? t(n).startOf(o) : t(n), o]
       }
       function o() {
@@ -18227,7 +18263,7 @@
               ? arguments[0]
               : null,
           n = arguments.length > 1 ? arguments[1] : void 0,
-          r = OO(n)
+          r = Ox(n)
         return r ? t(e).startOf(r).toDate() : t(e).toDate()
       }
       function a(e, t, n) {
@@ -18245,11 +18281,11 @@
         return a.isSameOrBefore(i, l)
       }
       function l(e, n, r) {
-        var o = OO(r)
+        var o = Ox(r)
         return t(e).add(n, o).toDate()
       }
       function u(e, t) {
-        var n = OO(t),
+        var n = Ox(t),
           r = o(e, n)
         return a(r, e) ? r : l(r, 1, n)
       }
@@ -18258,7 +18294,7 @@
             arguments.length > 2 && void 0 !== arguments[2]
               ? arguments[2]
               : 'day',
-          o = OO(r),
+          o = Ox(r),
           a = t(e),
           i = t(n)
         return i.diff(a, o)
@@ -18270,7 +18306,7 @@
         return t(e).endOf('month').endOf('week').toDate()
       }
       return new Pt({
-        formats: xO,
+        formats: xx,
         firstOfWeek: function (t) {
           var n = t ? e.localeData(t) : e.localeData()
           return n ? n.firstDayOfWeek() : 0
@@ -18324,7 +18360,7 @@
               arguments.length > 3 && void 0 !== arguments[3]
                 ? arguments[3]
                 : 'day',
-            a = OO(o),
+            a = Ox(o),
             i = t(e),
             l = t(n),
             u = t(r)
@@ -18337,7 +18373,7 @@
                 ? arguments[0]
                 : null,
             n = arguments.length > 1 ? arguments[1] : void 0,
-            r = OO(n)
+            r = Ox(n)
           return r ? t(e).endOf(r).toDate() : t(e).toDate()
         },
         range: function (e, n) {
@@ -18346,7 +18382,7 @@
                 arguments.length > 2 && void 0 !== arguments[2]
                   ? arguments[2]
                   : 'day',
-              o = OO(r),
+              o = Ox(r),
               a = t(e).toDate(),
               u = [];
             i(a, n);
@@ -18483,7 +18519,7 @@
                 return Math.abs(a.getDay() - i)
               }
             },
-            formats: eO,
+            formats: tx,
             format: function (e, n, r) {
               return (
                 (n = 'string' == typeof n ? { raw: n } : n),
@@ -18491,7 +18527,7 @@
               )
             },
           })
-        : Jx(e)
+        : Z_(e)
     }),
     (e.luxonLocalizer = function (e) {
       var t =
@@ -18505,7 +18541,7 @@
         return e.fromJSDate(t).setLocale(n).toFormat(r)
       }
       function l(t, n, r) {
-        var o = Qx(r)
+        var o = X_(r)
         return [
           o ? e.fromJSDate(t).startOf(o) : e.fromJSDate(t),
           o ? e.fromJSDate(n).startOf(o) : e.fromJSDate(n),
@@ -18536,7 +18572,7 @@
               ? arguments[0]
               : new Date(),
           n = arguments.length > 1 ? arguments[1] : void 0,
-          r = Qx(n)
+          r = X_(n)
         if (r) {
           var o = e.fromJSDate(t)
           return r.includes('week') ? u(o) : o.startOf(r)
@@ -18560,7 +18596,7 @@
               ? arguments[0]
               : new Date(),
           n = arguments.length > 1 ? arguments[1] : void 0,
-          r = Qx(n)
+          r = X_(n)
         if (r) {
           var o = e.fromJSDate(t)
           return r.includes('week') ? s(o) : o.endOf(r)
@@ -18603,7 +18639,7 @@
             arguments.length > 3 && void 0 !== arguments[3]
               ? arguments[3]
               : 'day',
-          o = Qx(r),
+          o = X_(r),
           a = c(e, o),
           i = c(t, o),
           l = c(n, o)
@@ -18619,7 +18655,7 @@
           o = e.fromJSDate(n)
         return e.max(r, o).toJSDate()
       }
-      function x(t, n) {
+      function _(t, n) {
         if (!t && !n) return null
         var r = e.fromJSDate(n)
         return c(t, 'day')
@@ -18631,36 +18667,36 @@
           })
           .toJSDate()
       }
-      function O(t, n, r) {
-        var a = Qx(r)
+      function x(t, n, r) {
+        var a = X_(r)
         return e.fromJSDate(t).plus(o({}, a, n)).toJSDate()
       }
-      function _(t, n) {
+      function O(t, n) {
         for (
           var r =
               arguments.length > 2 && void 0 !== arguments[2]
                 ? arguments[2]
                 : 'day',
-            o = Qx(r),
+            o = X_(r),
             a = e.fromJSDate(t).toJSDate(),
             i = [];
           w(a, n);
 
         )
-          i.push(a), (a = O(a, 1, o))
+          i.push(a), (a = x(a, 1, o))
         return i
       }
       function M(e, t) {
-        var n = Qx(t),
+        var n = X_(t),
           r = d(e, n)
-        return h(r, e) ? r : O(r, 1, n)
+        return h(r, e) ? r : x(r, 1, n)
       }
       function C(t, n) {
         var r =
             arguments.length > 2 && void 0 !== arguments[2]
               ? arguments[2]
               : 'day',
-          o = Qx(r),
+          o = X_(r),
           a = e.fromJSDate(t),
           i = e.fromJSDate(n)
         return Math.floor(
@@ -18675,7 +18711,7 @@
       }
       function R(e) {
         for (var t = T(e), n = P(e), r = []; w(t, n); )
-          r.push(t), (t = O(t, 1, 'day'))
+          r.push(t), (t = x(t, 1, 'day'))
         return r
       }
       function N(e, t, n) {
@@ -18748,7 +18784,7 @@
         format: function (e, t, n) {
           return n ? i(e, n, t) : a(e, t)
         },
-        formats: Kx,
+        formats: Q_,
         firstOfWeek: f,
         firstVisibleDay: T,
         lastVisibleDay: P,
@@ -18759,12 +18795,12 @@
         gte: b,
         eq: h,
         neq: m,
-        merge: x,
+        merge: _,
         inRange: k,
         startOf: d,
         endOf: v,
-        range: _,
-        add: O,
+        range: O,
+        add: x,
         diff: C,
         ceil: M,
         min: S,
@@ -18799,7 +18835,7 @@
         return e.tz.zone(l).utcOffset(+a) - e.tz.zone(l).utcOffset(+i)
       }
       function n(t, n, r) {
-        var o = Yx(r)
+        var o = q_(r)
         return [o ? e(t).startOf(o) : e(t), o ? e(n).startOf(o) : e(n), o]
       }
       function r() {
@@ -18808,7 +18844,7 @@
               ? arguments[0]
               : null,
           n = arguments.length > 1 ? arguments[1] : void 0,
-          r = Yx(n)
+          r = q_(n)
         return r ? e(t).startOf(r).toDate() : e(t).toDate()
       }
       function o(e, t, r) {
@@ -18826,11 +18862,11 @@
         return a.isSameOrBefore(i, l)
       }
       function i(t, n, r) {
-        var o = Yx(r)
+        var o = q_(r)
         return e(t).add(n, o).toDate()
       }
       function l(e, t) {
-        var n = Yx(t),
+        var n = q_(t),
           a = r(e, n)
         return o(a, e) ? a : i(a, 1, n)
       }
@@ -18839,7 +18875,7 @@
             arguments.length > 2 && void 0 !== arguments[2]
               ? arguments[2]
               : 'day',
-          o = Yx(r),
+          o = q_(r),
           a = e(t),
           i = e(n)
         return i.diff(a, o)
@@ -18851,7 +18887,7 @@
         return e(t).endOf('month').endOf('week').toDate()
       }
       return new Pt({
-        formats: $x,
+        formats: Y_,
         firstOfWeek: function (t) {
           var n = t ? e.localeData(t) : e.localeData()
           return n ? n.firstDayOfWeek() : 0
@@ -18905,7 +18941,7 @@
               arguments.length > 3 && void 0 !== arguments[3]
                 ? arguments[3]
                 : 'day',
-            a = Yx(o),
+            a = q_(o),
             i = e(t),
             l = e(n),
             u = e(r)
@@ -18918,7 +18954,7 @@
                 ? arguments[0]
                 : null,
             n = arguments.length > 1 ? arguments[1] : void 0,
-            r = Yx(n)
+            r = q_(n)
           return r ? e(t).endOf(r).toDate() : e(t).toDate()
         },
         range: function (t, n) {
@@ -18927,7 +18963,7 @@
                 arguments.length > 2 && void 0 !== arguments[2]
                   ? arguments[2]
                   : 'day',
-              o = Yx(r),
+              o = q_(r),
               l = e(t).toDate(),
               u = [];
             a(l, n);
@@ -19035,5 +19071,5 @@
         },
       })
     }),
-    (e.move = WE)
+    (e.move = HE)
 })

--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -1,10 +1,10 @@
-import React, { createRef } from 'react'
-import PropTypes from 'prop-types'
 import clsx from 'clsx'
+import PropTypes from 'prop-types'
+import React, { createRef } from 'react'
 
+import Selection, { getBoundsForNode, isEvent, isShowMore } from './Selection'
 import { notify } from './utils/helpers'
 import { dateCellSelection, getSlotAtX, pointInBox } from './utils/selection'
-import Selection, { getBoundsForNode, isEvent, isShowMore } from './Selection'
 
 class BackgroundCells extends React.Component {
   constructor(props, context) {
@@ -72,8 +72,10 @@ class BackgroundCells extends React.Component {
 
   _selectable() {
     let node = this.containerRef.current
+
     let selector = (this._selector = new Selection(this.props.container, {
       longPressThreshold: this.props.longPressThreshold,
+      targetHostMarker: this.containerRef.current,
     }))
 
     let selectorClicksHandler = (point, actionType) => {

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -1,15 +1,15 @@
-import React, { createRef } from 'react'
-import PropTypes from 'prop-types'
 import clsx from 'clsx'
+import PropTypes from 'prop-types'
+import React, { createRef } from 'react'
 
 import Selection, { getBoundsForNode, isEvent } from './Selection'
 import * as TimeSlotUtils from './utils/TimeSlots'
 import { isSelected } from './utils/selection'
 
-import { notify } from './utils/helpers'
-import * as DayEventLayout from './utils/DayEventLayout'
-import TimeSlotGroup from './TimeSlotGroup'
 import TimeGridEvent from './TimeGridEvent'
+import TimeSlotGroup from './TimeSlotGroup'
+import * as DayEventLayout from './utils/DayEventLayout'
+import { notify } from './utils/helpers'
 import { DayLayoutAlgorithmPropType } from './utils/propTypes'
 
 import DayColumnWrapper from './DayColumnWrapper'

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -257,6 +257,7 @@ class DayColumn extends React.Component {
     const { longPressThreshold, localizer } = this.props
     let selector = (this._selector = new Selection(() => node, {
       longPressThreshold: longPressThreshold,
+      targetHostMarker: this.containerRef.current,
     }))
 
     let maybeSelect = (box) => {

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -1,38 +1,65 @@
-import contains from 'dom-helpers/contains'
 import closest from 'dom-helpers/closest'
+import contains from 'dom-helpers/contains'
 import listen from 'dom-helpers/listen'
 
-const getTargetHost = (target = document) => {
-  if (target instanceof Document) {
-    const shadowRootElement = document.querySelector(
-      '[data-rh-content-portal-name=create-relay-meeting]'
-    )
+const RH_PORTAL_SELECTOR = '[data-rh-content-portal]'
 
-    if (shadowRootElement === null) return document
-
-    return shadowRootElement.shadowRoot
+/**
+ * get parent rh content portal shadow root
+ * we're not using the closest method as it doesn't work with shadow roots
+ * @param {HTMLElement | null | undefined} node
+ * @returns {ShadowRoot | null}
+ */
+function getParentShadowRoot(node) {
+  if (!node) {
+    return null
   }
 
-  return target
+  if (
+    node?.parentNode instanceof ShadowRoot &&
+    node?.parentNode?.host.matches(RH_PORTAL_SELECTOR)
+  ) {
+    return node.parentNode
+  }
+
+  return getParentShadowRoot(node.parentElement)
 }
 
-function addEventListener(type, handler, target = document) {
-  return listen(getTargetHost(target), type, handler, { passive: false })
+/**
+ * if the node is a html element, query for the closest shadowRoot
+ * @param {HTMLElement | Window} node
+ * @returns {HTMLElement | Window}
+ */
+const getTargetHost = (node) => {
+  if (!node || node instanceof Window) return node
+
+  const closestRHPortal = getParentShadowRoot(node)
+
+  if (closestRHPortal === null) {
+    return document
+  }
+
+  return closestRHPortal
+}
+
+function addEventListener(type, handler, target) {
+  return listen(target, type, handler, { passive: false })
 }
 
 function isOverContainer(container, x, y) {
   return (
-    !container || contains(container, getTargetHost().elementFromPoint(x, y))
+    !container ||
+    contains(container, getTargetHost(container).elementFromPoint(x, y))
   )
 }
 
 export function getEventNodeFromPoint(node, { clientX, clientY }) {
-  let target = getTargetHost().elementFromPoint(clientX, clientY)
+  let target = getTargetHost(node).elementFromPoint(clientX, clientY)
   return closest(target, '.rbc-event', node)
 }
 
 export function getShowMoreNodeFromPoint(node, { clientX, clientY }) {
-  let target = getTargetHost().elementFromPoint(clientX, clientY)
+  let target = getTargetHost(node).elementFromPoint(clientX, clientY)
   return closest(target, '.rbc-show-more', node)
 }
 
@@ -75,6 +102,13 @@ class Selection {
 
     this._listeners = Object.create(null)
 
+    /**
+     * !Note
+     * event listener target for container
+     * we need this to make the calendar work inside shadow roots
+     */
+    this._targetHost = getTargetHost(this.container)
+
     this._handleInitialEvent = this._handleInitialEvent.bind(this)
     this._handleMoveEvent = this._handleMoveEvent.bind(this)
     this._handleTerminatingEvent = this._handleTerminatingEvent.bind(this)
@@ -90,16 +124,31 @@ class Selection {
       () => {},
       window
     )
-    this._removeKeyDownListener = addEventListener('keydown', this._keyListener)
-    this._removeKeyUpListener = addEventListener('keyup', this._keyListener)
+
+    this._removeKeyDownListener = addEventListener(
+      'keydown',
+      this._keyListener,
+      this._targetHost
+    )
+
+    this._removeKeyUpListener = addEventListener(
+      'keyup',
+      this._keyListener,
+      this._targetHost
+    )
+
     this._removeDropFromOutsideListener = addEventListener(
       'drop',
-      this._dropFromOutsideListener
+      this._dropFromOutsideListener,
+      this._targetHost
     )
+
     this._removeDragOverFromOutsideListener = addEventListener(
       'dragover',
-      this._dragOverFromOutsideListener
+      this._dragOverFromOutsideListener,
+      this._targetHost
     )
+
     this._addInitialEventListener()
   }
 
@@ -163,18 +212,32 @@ class Selection {
     let timer = null
     let removeTouchMoveListener = null
     let removeTouchEndListener = null
+
     const handleTouchStart = (initialEvent) => {
       timer = setTimeout(() => {
         cleanup()
         handler(initialEvent)
       }, this.longPressThreshold)
-      removeTouchMoveListener = addEventListener('touchmove', () => cleanup())
-      removeTouchEndListener = addEventListener('touchend', () => cleanup())
+
+      removeTouchMoveListener = addEventListener(
+        'touchmove',
+        () => cleanup(),
+        this._targetHost
+      )
+
+      removeTouchEndListener = addEventListener(
+        'touchend',
+        () => cleanup(),
+        this._targetHost
+      )
     }
+
     const removeTouchStartListener = addEventListener(
       'touchstart',
-      handleTouchStart
+      handleTouchStart,
+      this._targetHost
     )
+
     const cleanup = () => {
       if (timer) {
         clearTimeout(timer)
@@ -204,21 +267,32 @@ class Selection {
   // Listen for mousedown and touchstart events. When one is received, disable the other and setup
   // future event handling based on the type of event.
   _addInitialEventListener() {
-    const removeMouseDownListener = addEventListener('mousedown', (e) => {
-      this._removeInitialEventListener()
-      this._handleInitialEvent(e)
-      this._removeInitialEventListener = addEventListener(
-        'mousedown',
-        this._handleInitialEvent
-      )
-    })
-    const removeTouchStartListener = addEventListener('touchstart', (e) => {
-      this._removeInitialEventListener()
-      this._removeInitialEventListener = this._addLongPressListener(
-        this._handleInitialEvent,
-        e
-      )
-    })
+    const removeMouseDownListener = addEventListener(
+      'mousedown',
+      (e) => {
+        this._removeInitialEventListener()
+        this._handleInitialEvent(e)
+
+        this._removeInitialEventListener = addEventListener(
+          'mousedown',
+          this._handleInitialEvent,
+          this._targetHost
+        )
+      },
+      this._targetHost
+    )
+
+    const removeTouchStartListener = addEventListener(
+      'touchstart',
+      (e) => {
+        this._removeInitialEventListener()
+        this._removeInitialEventListener = this._addLongPressListener(
+          this._handleInitialEvent,
+          e
+        )
+      },
+      this._targetHost
+    )
 
     this._removeInitialEventListener = () => {
       removeMouseDownListener()
@@ -305,27 +379,37 @@ class Selection {
       case 'mousedown':
         this._removeEndListener = addEventListener(
           'mouseup',
-          this._handleTerminatingEvent
+          this._handleTerminatingEvent,
+          this._targetHost
         )
+
         this._onEscListener = addEventListener(
           'keydown',
-          this._handleTerminatingEvent
+          this._handleTerminatingEvent,
+          this._targetHost
         )
+
         this._removeMoveListener = addEventListener(
           'mousemove',
-          this._handleMoveEvent
+          this._handleMoveEvent,
+          this._targetHost
         )
+
         break
       case 'touchstart':
         this._handleMoveEvent(e)
         this._removeEndListener = addEventListener(
           'touchend',
-          this._handleTerminatingEvent
+          this._handleTerminatingEvent,
+          this._targetHost
         )
+
         this._removeMoveListener = addEventListener(
           'touchmove',
-          this._handleMoveEvent
+          this._handleMoveEvent,
+          this._targetHost
         )
+
         break
       default:
         break

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -92,7 +92,12 @@ const clickInterval = 250
 class Selection {
   constructor(
     node,
-    { global = false, longPressThreshold = 250, validContainers = [] } = {}
+    {
+      global = false,
+      longPressThreshold = 250,
+      validContainers = [],
+      targetHostMarker = null,
+    } = {}
   ) {
     this.isDetached = false
     this.container = node
@@ -107,7 +112,7 @@ class Selection {
      * event listener target for container
      * we need this to make the calendar work inside shadow roots
      */
-    this._targetHost = getTargetHost(this.container)
+    this._targetHost = getTargetHost(targetHostMarker || this.container())
 
     this._handleInitialEvent = this._handleInitialEvent.bind(this)
     this._handleMoveEvent = this._handleMoveEvent.bind(this)

--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -1,8 +1,8 @@
+import { scrollParent, scrollTop } from 'dom-helpers'
+import qsa from 'dom-helpers/cjs/querySelectorAll'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { DnDContext } from './DnDContext'
-import { scrollParent, scrollTop } from 'dom-helpers'
-import qsa from 'dom-helpers/cjs/querySelectorAll'
 
 import Selection, {
   getBoundsForNode,
@@ -154,9 +154,15 @@ class EventContainerWrapper extends React.Component {
     let wrapper = this.ref.current
     let node = wrapper.children[0]
     let isBeingDragged = false
-    let selector = (this._selector = new Selection(() =>
-      wrapper.closest('.rbc-time-view')
-    ))
+
+    let selector =
+      ((this._selector = new Selection(() =>
+        wrapper.closest('.rbc-time-view')
+      )),
+      {
+        targetHostMarker: wrapper,
+      })
+
     let parent = scrollParent(wrapper)
 
     selector.on('beforeSelect', (point) => {

--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -4,8 +4,8 @@ import EventRow from '../../EventRow'
 import Selection, { getBoundsForNode } from '../../Selection'
 import { eventSegments } from '../../utils/eventLevels'
 import { getSlotAtX, pointInBox } from '../../utils/selection'
-import { dragAccessors, eventTimes } from './common'
 import { DnDContext } from './DnDContext'
+import { dragAccessors, eventTimes } from './common'
 
 class WeekWrapper extends React.Component {
   static propTypes = {
@@ -158,6 +158,7 @@ class WeekWrapper extends React.Component {
       validContainers: [
         ...(!isMonthRow ? ['.rbc-day-slot', '.rbc-allday-cell'] : []),
       ],
+      targetHostMarker: this.ref.current,
     }))
 
     selector.on('beforeSelect', (point) => {


### PR DESCRIPTION
## Description
- earlier we're checking if we had any rh portal in the dom and we took it as target for dom ops in selection (which handles selection of slots)
- now the problem with that is if in a page we have a calendar in main DOM and one inside a shadow DOM, it'll always take the shadow DOM one irrespective of the DOM tree


Fix:
- to fix this, for each node that we do DOM ops on, we query the parent to get the closest RH portal
- this way the target node will be always scoped to a specific DOM and component tree